### PR TITLE
Io handled by ethash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
+# making our travis.yml play well with C++11 by obtaining g++4.8
+# Taken from this file:
+# https://github.com/beark/ftl/blob/master/.travis.yml
 before_install:
-        - sudo apt-get update -qq
-        - sudo apt-get install -qq wget cmake gcc bash libboost-test-dev nodejs python-pip python-dev
-        - sudo pip install virtualenv -q
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -y -qq
 
+install:
+  - sudo apt-get install -qq --yes --force-yes g++-4.8
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+  # need to explicitly request version 1.48 since by default we get 1.46 which does not work with C++11
+  - sudo apt-get install -qq wget cmake bash libboost-test1.48-dev libboost-system1.48-dev libboost-filesystem1.48-dev nodejs python-pip python-dev
+  - sudo pip install virtualenv -q
 script: "./test/test.sh"

--- a/src/libethash/CMakeLists.txt
+++ b/src/libethash/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 set(FILES 	util.c
           	util.h
+          	io.c
           	internal.c
           	ethash.h
           	endian.h

--- a/src/libethash/CMakeLists.txt
+++ b/src/libethash/CMakeLists.txt
@@ -19,6 +19,12 @@ set(FILES 	util.c
           	fnv.h
           	data_sizes.h)
 
+if (MSVC)
+	list(APPEND FILES io_win32.c)
+else()
+	list(APPEND FILES io_posix.c)
+endif()
+
 if (NOT CRYPTOPP_FOUND)
 	find_package(CryptoPP 5.6.2)
 endif()

--- a/src/libethash/io.c
+++ b/src/libethash/io.c
@@ -1,0 +1,92 @@
+/*
+  This file is part of ethash.
+
+  ethash is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ethash is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ethash.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file io.c
+ * @author Lefteris Karapetsas <lefteris@ethdev.com>
+ * @date 2015
+ */
+#include "io.h"
+#include <string.h>
+#include <stdio.h>
+
+// silly macro to save some typing
+#define PASS_ARR(c_) (c_), sizeof(c_)
+
+static bool ethash_io_write_file(char const *dirname,
+                                 char const* filename,
+                                 size_t filename_length,
+                                 void const* data,
+                                 size_t data_size)
+{
+    bool ret = false;
+    char *fullname = ethash_io_create_filename(dirname, filename, filename_length);
+    if (!fullname) {
+        return false;
+    }
+    FILE *f = fopen(fullname, "wb");
+    if (!f) {
+        goto free_name;
+    }
+    if (data_size != fwrite(data, 1, data_size, f)) {
+        goto close;
+    }
+
+    ret = true;
+close:
+    fclose(f);
+free_name:
+    free(fullname);
+    return ret;
+}
+
+bool ethash_io_write(char const *dirname,
+                     uint32_t block_number,
+                     void const* cache,
+                     uint8_t **data,
+                     size_t *data_size)
+{
+    ethash_params p;
+    char info_buffer[DAG_MEMO_BYTESIZE];
+
+	p.cache_size = ethash_get_cachesize(block_number);
+	p.full_size = ethash_get_datasize(block_number);
+    // allocate the bytes
+    uint8_t *temp_data_ptr = malloc(p.full_size);
+    if (!(*temp_data_ptr)) {
+        goto end;
+    }
+    ethash_prep_full(temp_data_ptr, &p, cache);
+
+    if (!ethash_io_write_file(dirname, PASS_ARR(DAG_FILE_NAME), temp_data_ptr, p.full_size)) {
+        goto fail_free;
+    }
+
+    ethash_io_serialize_info(REVISION, block_number, info_buffer);
+    if (!ethash_io_write_file(dirname, PASS_ARR(DAG_MEMO_NAME), info_buffer, DAG_MEMO_BYTESIZE)) {
+        goto fail_free;
+    }
+
+    *data = temp_data_ptr;
+    *data_size = p.full_size;
+    return true;
+
+fail_free:
+    free(temp_data_ptr);
+end:
+    return false;
+}
+
+#undef PASS_ARR

--- a/src/libethash/io.c
+++ b/src/libethash/io.c
@@ -62,11 +62,11 @@ bool ethash_io_write(char const *dirname,
     char info_buffer[DAG_MEMO_BYTESIZE];
     ethash_blockhash_t seedhash;
 
-	p.cache_size = ethash_get_cachesize(block_number);
-	p.full_size = ethash_get_datasize(block_number);
+    p.cache_size = ethash_get_cachesize(block_number);
+    p.full_size = ethash_get_datasize(block_number);
     // allocate the bytes
     uint8_t *temp_data_ptr = malloc(p.full_size);
-    if (!(*temp_data_ptr)) {
+    if (!*temp_data_ptr) {
         goto end;
     }
     ethash_prep_full(temp_data_ptr, &p, cache);

--- a/src/libethash/io.c
+++ b/src/libethash/io.c
@@ -60,6 +60,7 @@ bool ethash_io_write(char const *dirname,
 {
     ethash_params p;
     char info_buffer[DAG_MEMO_BYTESIZE];
+    ethash_blockhash_t seedhash;
 
 	p.cache_size = ethash_get_cachesize(block_number);
 	p.full_size = ethash_get_datasize(block_number);
@@ -74,7 +75,8 @@ bool ethash_io_write(char const *dirname,
         goto fail_free;
     }
 
-    ethash_io_serialize_info(REVISION, block_number, info_buffer);
+    ethash_get_seedhash((uint8_t*)&seedhash, block_number);
+    ethash_io_serialize_info(REVISION, seedhash, info_buffer);
     if (!ethash_io_write_file(dirname, PASS_ARR(DAG_MEMO_NAME), info_buffer, DAG_MEMO_BYTESIZE)) {
         goto fail_free;
     }

--- a/src/libethash/io.h
+++ b/src/libethash/io.h
@@ -62,7 +62,9 @@ enum ethash_io_rc ethash_io_prepare(char const *dirname, ethash_blockhash_t seed
  *
  * @param[in] dirname        A null terminated c-string of the path of the ethash
  *                           data directory. Has to exist.
- * @param[in] block_number   The current block number.
+ * @param[in] params         An ethash_params object containing the full size
+ *                           and the cache size
+ * @param[in] seedhash       The seedhash of the current block number
  * @param[in] cache          The cache data. Would have usually been calulated by
  *                           @see ethash_prep_light().
  * @param[out] data          Pass a pointer to uint8_t by reference here. If the
@@ -76,7 +78,8 @@ enum ethash_io_rc ethash_io_prepare(char const *dirname, ethash_blockhash_t seed
  * @return                   True for success and false in case of failure.
  */
 bool ethash_io_write(char const *dirname,
-                     uint32_t block_number,
+                     ethash_params const* params,
+                     ethash_blockhash_t seedhash,
                      void const* cache,
                      uint8_t **data,
                      size_t *data_size);
@@ -94,7 +97,8 @@ static inline char *ethash_io_create_filename(char const *dirname,
                                               char const* filename,
                                               size_t filename_length)
 {
-    char *name = malloc(strlen(dirname) + filename_length);
+    // in C the cast is not needed, but a C++ compiler will complain for invalid conversion
+    char *name = (char*)malloc(strlen(dirname) + filename_length);
     if (!name) {
         return NULL;
     }

--- a/src/libethash/io.h
+++ b/src/libethash/io.h
@@ -1,0 +1,53 @@
+/*
+  This file is part of ethash.
+
+  ethash is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ethash is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ethash.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file io.h
+ * @author Lefteris Karapetsas <lefteris@ethdev.com>
+ * @date 2015
+ */
+#pragma once
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include "ethash.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Prepares io for ethash
+ * @param dirname        A null terminated c-string of the path of the ethash
+ *                       data directory. If it does not exist it's created.
+ * @param block_number   The current block number. Used in seedhash calculation.
+ * @returns              True if all went fine, and false if there was any kind
+ *                       of error
+ */
+bool ethash_io_prepare(char const *dirname, uint32_t block_number);
+void ethash_io_write();
+static inline void ethash_io_serialize_info(uint32_t revision,
+                                            uint32_t block_number,
+                                            char *output)
+{
+    // if .info is only consumed locally we don't really care about endianess
+    memcpy(output, &revision, 4);
+    ethash_get_seedhash((uint8_t*)(output + 4), block_number);
+}
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/libethash/io.h
+++ b/src/libethash/io.h
@@ -28,6 +28,8 @@
 extern "C" {
 #endif
 
+typedef struct ethash_blockhash { uint8_t b[32]; } ethash_blockhash_t;
+
 static const char DAG_FILE_NAME[] = "full";
 static const char DAG_MEMO_NAME[] = "full.info";
 static const unsigned int DAG_MEMO_BYTESIZE = 36;
@@ -47,10 +49,10 @@ enum ethash_io_rc {
  *
  * @param dirname        A null terminated c-string of the path of the ethash
  *                       data directory. If it does not exist it's created.
- * @param block_number   The current block number. Used in seedhash calculation.
+ * @param seedhash       The seedhash of the current block number
  * @return               For possible return values @see enum ethash_io_rc
  */
-enum ethash_io_rc ethash_io_prepare(char const *dirname, uint32_t block_number);
+enum ethash_io_rc ethash_io_prepare(char const *dirname, ethash_blockhash_t seedhash);
 /**
  * Fully computes data and writes it to the file on disk.
  *
@@ -80,12 +82,12 @@ bool ethash_io_write(char const *dirname,
                      size_t *data_size);
 
 static inline void ethash_io_serialize_info(uint32_t revision,
-                                            uint32_t block_number,
+                                            ethash_blockhash_t seed_hash,
                                             char *output)
 {
     // if .info is only consumed locally we don't really care about endianess
     memcpy(output, &revision, 4);
-    ethash_get_seedhash((uint8_t*)(output + 4), block_number);
+    memcpy(output + 4, &seed_hash, 32);
 }
 
 static inline char *ethash_io_create_filename(char const *dirname,

--- a/src/libethash/io_posix.c
+++ b/src/libethash/io_posix.c
@@ -27,7 +27,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-enum ethash_io_rc ethash_io_prepare(char const *dirname, uint32_t block_number)
+enum ethash_io_rc ethash_io_prepare(char const *dirname, ethash_blockhash_t seedhash)
 {
     char read_buffer[DAG_MEMO_BYTESIZE];
     char expect_buffer[DAG_MEMO_BYTESIZE];
@@ -56,7 +56,7 @@ enum ethash_io_rc ethash_io_prepare(char const *dirname, uint32_t block_number)
         goto close;
     }
 
-    ethash_io_serialize_info(REVISION, block_number, expect_buffer);
+    ethash_io_serialize_info(REVISION, seedhash, expect_buffer);
     if (memcmp(read_buffer, expect_buffer, DAG_MEMO_BYTESIZE) != 0) {
         // we have different memo contents so delete the memo file
         if (unlink(memofile) != 0) {

--- a/src/libethash/io_posix.c
+++ b/src/libethash/io_posix.c
@@ -60,9 +60,9 @@ enum ethash_io_rc ethash_io_prepare(char const *dirname, uint32_t block_number)
     if (memcmp(read_buffer, expect_buffer, DAG_MEMO_BYTESIZE) != 0) {
         // we have different memo contents so delete the memo file
         if (unlink(memofile) != 0) {
-            ret = ETHASH_IO_MEMO_MISMATCH;
             goto close;
         }
+        ret = ETHASH_IO_MEMO_MISMATCH;
     }
 
     ret = ETHASH_IO_MEMO_MATCH;

--- a/src/libethash/io_posix.c
+++ b/src/libethash/io_posix.c
@@ -1,0 +1,82 @@
+/*
+  This file is part of ethash.
+
+  ethash is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ethash is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ethash.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file io_posix.c
+ * @author Lefteris Karapetsas <lefteris@ethdev.com>
+ * @date 2015
+ */
+#include "io.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <libgen.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+
+static const char DAG_FILE_NAME[] = "full";
+static const char DAG_MEMO_NAME[] = "full.info";
+static const unsigned int DAG_MEMO_BYTESIZE = 36;
+
+bool ethash_io_prepare(char const *dirname, uint32_t block_number)
+{
+    char read_buffer[DAG_MEMO_BYTESIZE];
+    char expect_buffer[DAG_MEMO_BYTESIZE];
+    bool ret = false;
+
+    // assert directory exists, full owner permissions and read/search for others
+    int rc = mkdir(dirname, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+    if (rc == -1 && errno != EEXIST) {
+        goto end;
+    }
+
+    // try to open memo file
+    char *memofile = malloc(strlen(dirname) + sizeof(DAG_MEMO_NAME));
+    if (!memofile) {
+        goto end;
+    }
+
+    FILE *f = fopen(memofile, "rb");
+    if (!f) {
+        // file does not exist, so no checking happens. All is fine.
+        ret = true;
+        goto free_memo;
+    }
+
+    if (fread(read_buffer, 1, DAG_MEMO_BYTESIZE, f) != DAG_MEMO_BYTESIZE) {
+        goto free_memo;
+    }
+
+    ethash_io_serialize_info(REVISION, block_number, expect_buffer);
+    if (memcmp(read_buffer, expect_buffer, DAG_MEMO_BYTESIZE) != 0) {
+        // we have different memo contents so delete the memo file
+        if (unlink(memofile) != 0) {
+            goto free_memo;
+        }
+    }
+
+    ret = true;
+
+free_memo:
+    free(memofile);
+end:
+    return ret;
+}
+
+void ethash_io_write()
+{
+}
+

--- a/src/libethash/io_win32.c
+++ b/src/libethash/io_win32.c
@@ -14,18 +14,15 @@
   You should have received a copy of the GNU General Public License
   along with ethash.  If not, see <http://www.gnu.org/licenses/>.
 */
-/** @file io_posix.c
+/** @file io_win32.c
  * @author Lefteris Karapetsas <lefteris@ethdev.com>
  * @date 2015
  */
 
 #include "io.h"
-#include <sys/types.h>
-#include <sys/stat.h>
+#include <direct.h>
 #include <errno.h>
-#include <libgen.h>
 #include <stdio.h>
-#include <unistd.h>
 
 enum ethash_io_rc ethash_io_prepare(char const *dirname, uint32_t block_number)
 {
@@ -33,8 +30,8 @@ enum ethash_io_rc ethash_io_prepare(char const *dirname, uint32_t block_number)
     char expect_buffer[DAG_MEMO_BYTESIZE];
     enum ethash_io_rc ret = ETHASH_IO_FAIL;
 
-    // assert directory exists, full owner permissions and read/search for others
-    int rc = mkdir(dirname, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+    // assert directory exists
+    int rc = _mkdir(dirname);
     if (rc == -1 && errno != EEXIST) {
         goto end;
     }
@@ -59,7 +56,7 @@ enum ethash_io_rc ethash_io_prepare(char const *dirname, uint32_t block_number)
     ethash_io_serialize_info(REVISION, block_number, expect_buffer);
     if (memcmp(read_buffer, expect_buffer, DAG_MEMO_BYTESIZE) != 0) {
         // we have different memo contents so delete the memo file
-        if (unlink(memofile) != 0) {
+        if (_unlink(memofile) != 0) {
             ret = ETHASH_IO_MEMO_MISMATCH;
             goto close;
         }

--- a/src/libethash/io_win32.c
+++ b/src/libethash/io_win32.c
@@ -57,9 +57,9 @@ enum ethash_io_rc ethash_io_prepare(char const *dirname, uint32_t block_number)
     if (memcmp(read_buffer, expect_buffer, DAG_MEMO_BYTESIZE) != 0) {
         // we have different memo contents so delete the memo file
         if (_unlink(memofile) != 0) {
-            ret = ETHASH_IO_MEMO_MISMATCH;
             goto close;
         }
+        ret = ETHASH_IO_MEMO_MISMATCH;
     }
 
     ret = ETHASH_IO_MEMO_MATCH;

--- a/src/libethash/io_win32.c
+++ b/src/libethash/io_win32.c
@@ -24,7 +24,7 @@
 #include <errno.h>
 #include <stdio.h>
 
-enum ethash_io_rc ethash_io_prepare(char const *dirname, uint32_t block_number)
+enum ethash_io_rc ethash_io_prepare(char const *dirname, ethash_blockhash_t seedhash)
 {
     char read_buffer[DAG_MEMO_BYTESIZE];
     char expect_buffer[DAG_MEMO_BYTESIZE];
@@ -53,7 +53,7 @@ enum ethash_io_rc ethash_io_prepare(char const *dirname, uint32_t block_number)
         goto close;
     }
 
-    ethash_io_serialize_info(REVISION, block_number, expect_buffer);
+    ethash_io_serialize_info(REVISION, seedhash, expect_buffer);
     if (memcmp(read_buffer, expect_buffer, DAG_MEMO_BYTESIZE) != 0) {
         // we have different memo contents so delete the memo file
         if (_unlink(memofile) != 0) {

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -1,5 +1,5 @@
 IF( NOT Boost_FOUND )
-    find_package(Boost COMPONENTS unit_test_framework)
+    find_package(Boost 1.48.0 REQUIRED COMPONENTS unit_test_framework system filesystem)
 ENDIF()
 
 IF( Boost_FOUND )
@@ -18,8 +18,17 @@ IF( Boost_FOUND )
 	    add_definitions(-DWITH_CRYPTOPP)
     endif()
 
+   if (NOT ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC"))
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -std=c++11 ")
+   endif()
+
     add_executable (Test test.cpp ${HEADERS})
-    target_link_libraries (Test ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${ETHHASH_LIBS})
+    target_link_libraries (Test ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+    target_link_libraries(Test ${ETHHASH_LIBS})
+    target_link_libraries(Test ${Boost_FILESYSTEM_LIBRARIES})
+    target_link_libraries(Test ${Boost_SYSTEM_LIBRARIES})
+    target_link_libraries (Test ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+    target_link_libraries (Test ${ETHHASH_LIBS})
 
     if (CRYPTOPP_FOUND)
 	    TARGET_LINK_LIBRARIES(Test ${CRYPTOPP_LIBRARIES})

--- a/test/c/test.cpp
+++ b/test/c/test.cpp
@@ -2,6 +2,7 @@
 #include <libethash/fnv.h>
 #include <libethash/ethash.h>
 #include <libethash/internal.h>
+#include <libethash/io.h>
 
 #ifdef WITH_CRYPTOPP
 
@@ -14,8 +15,14 @@
 #define BOOST_TEST_MODULE Daggerhashimoto
 #define BOOST_TEST_MAIN
 
-#include <boost/test/unit_test.hpp>
 #include <iostream>
+#include <fstream>
+#include <vector>
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+
+using namespace std;
+namespace fs = boost::filesystem;
 
 std::string bytesToHexString(const uint8_t *str, const size_t s) {
     std::ostringstream ret;
@@ -225,4 +232,146 @@ BOOST_AUTO_TEST_CASE(ethash_check_difficulty_check) {
     BOOST_REQUIRE_MESSAGE(
             !ethash_check_difficulty(hash, target),
             "\nexpected \"" << hash << "\" to have more difficulty than \"" << target << "\"\n");
+}
+
+BOOST_AUTO_TEST_CASE(test_ethash_dir_creation) {
+    ethash_blockhash_t seedhash;
+    BOOST_REQUIRE_EQUAL(
+        ETHASH_IO_MEMO_MISMATCH,
+        ethash_io_prepare("./test_ethash_directory/", seedhash)
+    );
+
+    // let's make sure that the directory was created
+    BOOST_REQUIRE(fs::is_directory(fs::path("./test_ethash_directory/")));
+
+    // cleanup
+    fs::remove_all("./test_ethash_directory/");
+}
+
+BOOST_AUTO_TEST_CASE(test_ethash_io_write_files_are_created) {
+    ethash_blockhash_t seedhash;
+    static const int blockn = 0;
+    ethash_get_seedhash((uint8_t*)&seedhash, blockn);
+    BOOST_REQUIRE_EQUAL(
+        ETHASH_IO_MEMO_MISMATCH,
+        ethash_io_prepare("./test_ethash_directory/", seedhash)
+    );
+
+ // let's make sure that the directory was created
+    BOOST_REQUIRE(fs::is_directory(fs::path("./test_ethash_directory/")));
+
+    ethash_cache cache;
+    ethash_params params;
+    uint8_t *data;
+    size_t size;
+    ethash_params_init(&params, blockn);
+    params.cache_size = 1024;
+    params.full_size = 1024 * 32;
+    cache.mem = alloca(params.cache_size);
+    ethash_mkcache(&cache, &params, (uint8_t*)&seedhash);
+
+    BOOST_REQUIRE(
+        ethash_io_write("./test_ethash_directory/", &params, seedhash, &cache, &data, &size)
+    );
+
+    BOOST_REQUIRE(fs::exists(fs::path("./test_ethash_directory/full")));
+    BOOST_REQUIRE(fs::exists(fs::path("./test_ethash_directory/full.info")));
+
+    // cleanup
+    fs::remove_all("./test_ethash_directory/");
+    free(data);
+}
+
+BOOST_AUTO_TEST_CASE(test_ethash_io_memo_file_match) {
+    ethash_blockhash_t seedhash;
+    static const int blockn = 0;
+    ethash_get_seedhash((uint8_t*)&seedhash, blockn);
+    BOOST_REQUIRE_EQUAL(
+        ETHASH_IO_MEMO_MISMATCH,
+        ethash_io_prepare("./test_ethash_directory/", seedhash)
+    );
+
+    // let's make sure that the directory was created
+    BOOST_REQUIRE(fs::is_directory(fs::path("./test_ethash_directory/")));
+
+    ethash_cache cache;
+    ethash_params params;
+    uint8_t *data;
+    size_t size;
+    ethash_params_init(&params, blockn);
+    params.cache_size = 1024;
+    params.full_size = 1024 * 32;
+    cache.mem = alloca(params.cache_size);
+    ethash_mkcache(&cache, &params, (uint8_t*)&seedhash);
+
+    BOOST_REQUIRE(
+        ethash_io_write("./test_ethash_directory/", &params, seedhash, &cache, &data, &size)
+    );
+
+    BOOST_REQUIRE(fs::exists(fs::path("./test_ethash_directory/full")));
+    BOOST_REQUIRE(fs::exists(fs::path("./test_ethash_directory/full.info")));
+
+    BOOST_REQUIRE_EQUAL(
+        ETHASH_IO_MEMO_MATCH,
+        ethash_io_prepare("./test_ethash_directory/", seedhash)
+    );
+
+    // cleanup
+    fs::remove_all("./test_ethash_directory/");
+    free(data);
+}
+
+// could have used dev::contentsNew but don't wanna try to import
+// libdevcore just for one function
+static std::vector<char> readFileIntoVector(char const* filename)
+{
+    ifstream ifs(filename, ios::binary|ios::ate);
+    ifstream::pos_type pos = ifs.tellg();
+
+    std::vector<char> result(pos);
+
+    ifs.seekg(0, ios::beg);
+    ifs.read(&result[0], pos);
+
+    return result;
+}
+
+BOOST_AUTO_TEST_CASE(test_ethash_io_memo_file_contents) {
+    ethash_blockhash_t seedhash;
+    static const int blockn = 0;
+    ethash_get_seedhash((uint8_t*)&seedhash, blockn);
+    BOOST_REQUIRE_EQUAL(
+        ETHASH_IO_MEMO_MISMATCH,
+        ethash_io_prepare("./test_ethash_directory/", seedhash)
+    );
+
+    // let's make sure that the directory was created
+    BOOST_REQUIRE(fs::is_directory(fs::path("./test_ethash_directory/")));
+
+    ethash_cache cache;
+    ethash_params params;
+    uint8_t *data;
+    size_t size;
+    ethash_params_init(&params, blockn);
+    params.cache_size = 1024;
+    params.full_size = 1024 * 32;
+    cache.mem = alloca(params.cache_size);
+    ethash_mkcache(&cache, &params, (uint8_t*)&seedhash);
+
+    BOOST_REQUIRE(
+        ethash_io_write("./test_ethash_directory/", &params, seedhash, &cache, &data, &size)
+    );
+
+    BOOST_REQUIRE(fs::exists(fs::path("./test_ethash_directory/full")));
+    BOOST_REQUIRE(fs::exists(fs::path("./test_ethash_directory/full.info")));
+
+    char expect_buffer[DAG_MEMO_BYTESIZE];
+    ethash_io_serialize_info(REVISION, seedhash, expect_buffer);
+    auto vec = readFileIntoVector("./test_ethash_directory/full.info");
+    BOOST_REQUIRE_EQUAL(vec.size(), DAG_MEMO_BYTESIZE);
+    BOOST_REQUIRE(memcmp(expect_buffer, &vec[0], DAG_MEMO_BYTESIZE) == 0);
+
+    // cleanup
+    fs::remove_all("./test_ethash_directory/");
+    free(data);
 }


### PR DESCRIPTION
- Work in progress

- For clarity and for future extendability have 2 different source files that are conditionally compiled depending on being in Windows or not for the function that makes calls to OS dependent functions.

- I created these 2 functions that are intended to be used by the clients by looking at how the C++ client writes the DAG in the disk.
     - One would call `ethash_io_prepare()` first to make sure the directory exists and check if the memo file's contents match with the current block hash. 

    - If there is a mismatch then you would call `ethash_io_write()` which would compute the full data just like `ethash_prep_full()` would, write it to the disk along with the memo file and also return them.


Have not yet tried to use it from the C++ client but need to first see if the PR will build in Windows.
