### PR TITLE
Use ethash_blockhash_t in the codebase

### DIFF
--- a/ethash.go
+++ b/ethash.go
@@ -94,7 +94,7 @@ func makeParamsAndCache(chainManager pow.ChainManager, blockNum uint64) (*Params
 
 	powlogger.Infoln("Making Cache")
 	start := time.Now()
-	C.ethash_mkcache(paramsAndCache.cache, paramsAndCache.params, (*C.uint8_t)(unsafe.Pointer(&seedHash[0])))
+	C.ethash_mkcache(paramsAndCache.cache, paramsAndCache.params, (*C.ethash_blockhash_t)(unsafe.Pointer(&seedHash[0])))
 	powlogger.Infoln("Took:", time.Since(start))
 
 	return paramsAndCache, nil
@@ -319,7 +319,7 @@ func (pow *Ethash) Search(block pow.Block, stop <-chan struct{}) (uint64, []byte
 	start := time.Now().UnixNano()
 
 	nonce := uint64(r.Int63())
-	cMiningHash := (*C.uint8_t)(unsafe.Pointer(&miningHash[0]))
+	cMiningHash := (*C.ethash_blockhash_t)(unsafe.Pointer(&miningHash[0]))
 	target := new(big.Int).Div(minDifficulty, diff)
 
 	var ret C.ethash_return_value
@@ -337,11 +337,11 @@ func (pow *Ethash) Search(block pow.Block, stop <-chan struct{}) (uint64, []byte
 			pow.HashRate = int64(hashes)
 
 			C.ethash_full(&ret, pow.dag.dag, pow.dag.paramsAndCache.params, cMiningHash, C.uint64_t(nonce))
-			result := common.Bytes2Big(C.GoBytes(unsafe.Pointer(&ret.result[0]), C.int(32)))
+			result := common.Bytes2Big(C.GoBytes(unsafe.Pointer(&ret.result), C.int(32)))
 
 			// TODO: disagrees with the spec https://github.com/ethereum/wiki/wiki/Ethash#mining
 			if result.Cmp(target) <= 0 {
-				mixDigest := C.GoBytes(unsafe.Pointer(&ret.mix_hash[0]), C.int(32))
+				mixDigest := C.GoBytes(unsafe.Pointer(&ret.mix_hash), C.int(32))
 				seedHash, err := GetSeedHash(block.NumberU64()) // This seedhash is useless
 				if err != nil {
 					panic(err)
@@ -374,7 +374,7 @@ func (pow *Ethash) verify(hash common.Hash, mixDigest common.Hash, difficulty *b
 
 	// First check: make sure header, mixDigest, nonce are correct without hitting the cache
 	// This is to prevent DOS attacks
-	chash := (*C.uint8_t)(unsafe.Pointer(&hash[0]))
+	chash := (*C.ethash_blockhash_t)(unsafe.Pointer(&hash[0]))
 	cnonce := C.uint64_t(nonce)
 	target := new(big.Int).Div(minDifficulty, difficulty)
 
@@ -402,7 +402,7 @@ func (pow *Ethash) verify(hash common.Hash, mixDigest common.Hash, difficulty *b
 
 	C.ethash_light(ret, pAc.cache, pAc.params, chash, cnonce)
 
-	result := common.Bytes2Big(C.GoBytes(unsafe.Pointer(&ret.result[0]), C.int(32)))
+	result := common.Bytes2Big(C.GoBytes(unsafe.Pointer(&ret.result), C.int(32)))
 	return result.Cmp(target) <= 0
 }
 
@@ -418,7 +418,7 @@ func (pow *Ethash) FullHash(nonce uint64, miningHash []byte) []byte {
 	pow.UpdateDAG()
 	pow.dagMutex.Lock()
 	defer pow.dagMutex.Unlock()
-	cMiningHash := (*C.uint8_t)(unsafe.Pointer(&miningHash[0]))
+	cMiningHash := (*C.ethash_blockhash_t)(unsafe.Pointer(&miningHash[0]))
 	cnonce := C.uint64_t(nonce)
 	ret := new(C.ethash_return_value)
 	// pow.hash is the output/return of ethash_full
@@ -428,7 +428,7 @@ func (pow *Ethash) FullHash(nonce uint64, miningHash []byte) []byte {
 }
 
 func (pow *Ethash) LightHash(nonce uint64, miningHash []byte) []byte {
-	cMiningHash := (*C.uint8_t)(unsafe.Pointer(&miningHash[0]))
+	cMiningHash := (*C.ethash_blockhash_t)(unsafe.Pointer(&miningHash[0]))
 	cnonce := C.uint64_t(nonce)
 	ret := new(C.ethash_return_value)
 	C.ethash_light(ret, pow.paramsAndCache.cache, pow.paramsAndCache.params, cMiningHash, cnonce)

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,34 @@
 #!/usr/bin/env python
 from distutils.core import setup, Extension
- 
-pyethash = Extension('pyethash', 
-        sources = [
-            'src/python/core.c', 
-            'src/libethash/util.c', 
-            'src/libethash/internal.c',
-            'src/libethash/sha3.c'],
-        depends = [
-            'src/libethash/ethash.h',
-            'src/libethash/compiler.h',
-            'src/libethash/data_sizes.h',
-            'src/libethash/endian.h',
-            'src/libethash/ethash.h',
-            'src/libethash/fnv.h',
-            'src/libethash/internal.h',
-            'src/libethash/sha3.h',
-            'src/libethash/util.h'
-            ],
-        extra_compile_args = ["-Isrc/", "-std=gnu99", "-Wall"])
- 
-setup (
-       name = 'pyethash',
-       author = "Matthew Wampler-Doty",
-       author_email = "matthew.wampler.doty@gmail.com",
-       license = 'GPL',
-       version = '23',
-       url = 'https://github.com/ethereum/ethash',
-       download_url = 'https://github.com/ethereum/ethash/tarball/v23',
-       description = 'Python wrappers for ethash, the ethereum proof of work hashing function',
-       ext_modules = [pyethash],
-      )
+
+pyethash = Extension('pyethash',
+                     sources=[
+                         'src/python/core.c',
+                         'src/libethash/util.c',
+                         'src/libethash/internal.c',
+                         'src/libethash/sha3.c'],
+                     depends=[
+                         'src/libethash/ethash.h',
+                         'src/libethash/compiler.h',
+                         'src/libethash/data_sizes.h',
+                         'src/libethash/endian.h',
+                         'src/libethash/ethash.h',
+                         'src/libethash/fnv.h',
+                         'src/libethash/internal.h',
+                         'src/libethash/sha3.h',
+                         'src/libethash/util.h'
+                     ],
+                     extra_compile_args=["-Isrc/", "-std=gnu99", "-Wall"])
+
+setup(
+    name='pyethash',
+    author="Matthew Wampler-Doty",
+    author_email="matthew.wampler.doty@gmail.com",
+    license='GPL',
+    version='0.1.23',
+    url='https://github.com/ethereum/ethash',
+    download_url='https://github.com/ethereum/ethash/tarball/v23',
+    description=('Python wrappers for ethash, the ethereum proof of work'
+                 'hashing function'),
+    ext_modules=[pyethash],
+)

--- a/src/benchmark/benchmark.cpp
+++ b/src/benchmark/benchmark.cpp
@@ -106,10 +106,11 @@ extern "C" int main(void)
 	//params.full_size = 8209 * 4096;	// 8MBish;
 	//params.cache_size = 8209*4096;
 	//params.cache_size = 2053*4096;
-	uint8_t seed[32], previous_hash[32];
+	ethash_blockhash_t seed;
+	ethash_blockhash_t previous_hash;
 
-	memcpy(seed, hexStringToBytes("9410b944535a83d9adf6bbdcc80e051f30676173c16ca0d32d6f1263fc246466").data(), 32);
-	memcpy(previous_hash, hexStringToBytes("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470").data(), 32);
+	memcpy(&seed, hexStringToBytes("9410b944535a83d9adf6bbdcc80e051f30676173c16ca0d32d6f1263fc246466").data(), 32);
+	memcpy(&previous_hash, hexStringToBytes("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470").data(), 32);
 	
 	// allocate page aligned buffer for dataset
 #ifdef FULL
@@ -128,9 +129,9 @@ extern "C" int main(void)
 		ethash_mkcache(&cache, &params, seed);
 		auto time = std::chrono::duration_cast<std::chrono::milliseconds>(high_resolution_clock::now() - startTime).count();
 
-		uint8_t cache_hash[32];
-		SHA3_256(cache_hash, (uint8_t const*)cache_mem, params.cache_size);
-		debugf("ethash_mkcache: %ums, sha3: %s\n", (unsigned)time, bytesToHexString(cache_hash,sizeof(cache_hash)).data());
+		ethash_blockhash_t cache_hash;
+		SHA3_256(&cache_hash, (uint8_t const*)cache_mem, params.cache_size);
+		debugf("ethash_mkcache: %ums, sha3: %s\n", (unsigned)((time*1000)/CLOCKS_PER_SEC), bytesToHexString(cache_hash,sizeof(cache_hash)).data());
 
 		// print a couple of test hashes
 		{

--- a/src/libethash-cl/ethash_cl_miner.cpp
+++ b/src/libethash-cl/ethash_cl_miner.cpp
@@ -54,15 +54,7 @@ ethash_cl_miner::ethash_cl_miner()
 {
 }
 
-void ethash_cl_miner::finish()
-{
-	if (m_queue())
-	{
-		m_queue.finish();
-	}
-}
-
-bool ethash_cl_miner::init(ethash_params const& params, const uint8_t seed[32], unsigned workgroup_size)
+bool ethash_cl_miner::init(ethash_params const& params, ethash_blockhash_t const *seed, unsigned workgroup_size)
 {
 	// store params
 	m_params = params;

--- a/src/libethash-cl/ethash_cl_miner.h
+++ b/src/libethash-cl/ethash_cl_miner.h
@@ -19,7 +19,7 @@ public:
 public:
 	ethash_cl_miner();
 
-	bool init(ethash_params const& params, const uint8_t seed[32], unsigned workgroup_size = 64);
+	bool init(ethash_params const& params, ethash_blockhash_t const *seed, unsigned workgroup_size = 64);
 
 	void finish();
 	void hash(uint8_t* ret, uint8_t const* header, uint64_t nonce, unsigned count);

--- a/src/libethash/internal.h
+++ b/src/libethash/internal.h
@@ -30,18 +30,15 @@ typedef union node {
 
 } node;
 
-void ethash_calculate_dag_item(
-        node *const ret,
-        const unsigned node_index,
-        ethash_params const *params,
-        ethash_cache const *cache
-);
+void ethash_calculate_dag_item(node *const ret,
+                               const unsigned node_index,
+                               ethash_params const *params,
+                               ethash_cache const *cache);
 
-void ethash_quick_hash(
-        uint8_t return_hash[32],
-        const uint8_t header_hash[32],
-        const uint64_t nonce,
-        const uint8_t mix_hash[32]);
+void ethash_quick_hash(ethash_blockhash_t *return_hash,
+                       ethash_blockhash_t const *header_hash,
+                       const uint64_t nonce,
+                       ethash_blockhash_t const *mix_hash);
 
 #ifdef __cplusplus
 }

--- a/src/libethash/io.h
+++ b/src/libethash/io.h
@@ -28,8 +28,6 @@
 extern "C" {
 #endif
 
-typedef struct ethash_blockhash { uint8_t b[32]; } ethash_blockhash_t;
-
 static const char DAG_FILE_NAME[] = "full";
 static const char DAG_MEMO_NAME[] = "full.info";
 // MSVC thinks that "static const unsigned int" is not a compile time variable. Sorry for the #define :(

--- a/src/libethash/io.h
+++ b/src/libethash/io.h
@@ -54,6 +54,7 @@ enum ethash_io_rc {
  * @return               For possible return values @see enum ethash_io_rc
  */
 enum ethash_io_rc ethash_io_prepare(char const *dirname, ethash_blockhash_t seedhash);
+
 /**
  * Fully computes data and writes it to the file on disk.
  *

--- a/src/libethash/sha3.h
+++ b/src/libethash/sha3.h
@@ -8,17 +8,21 @@ extern "C" {
 #include <stdint.h>
 #include <stdlib.h>
 
+struct ethash_blockhash;
+
 #define decsha3(bits) \
   int sha3_##bits(uint8_t*, size_t, const uint8_t*, size_t);
 
 decsha3(256)
 decsha3(512)
 
-static inline void SHA3_256(uint8_t * const ret, uint8_t const *data, const size_t size) {
-    sha3_256(ret, 32, data, size);
+static inline void SHA3_256(struct ethash_blockhash const* ret, uint8_t const *data, const size_t size)
+{
+    sha3_256((uint8_t*)ret, 32, data, size);
 }
 
-static inline void SHA3_512(uint8_t * const ret, uint8_t const *data, const size_t size) {
+static inline void SHA3_512(uint8_t const *ret, uint8_t const *data, const size_t size)
+{
     sha3_512(ret, 64, data, size);
 }
 

--- a/src/libethash/sha3.h
+++ b/src/libethash/sha3.h
@@ -21,7 +21,7 @@ static inline void SHA3_256(struct ethash_blockhash const* ret, uint8_t const *d
     sha3_256((uint8_t*)ret, 32, data, size);
 }
 
-static inline void SHA3_512(uint8_t const *ret, uint8_t const *data, const size_t size)
+static inline void SHA3_512(uint8_t *ret, uint8_t const *data, const size_t size)
 {
     sha3_512(ret, 64, data, size);
 }

--- a/src/libethash/sha3_cryptopp.cpp
+++ b/src/libethash/sha3_cryptopp.cpp
@@ -19,13 +19,14 @@
 * @author Tim Hughes <tim@twistedfury.com>
 * @date 2015
 */
-
 #include <stdint.h>
 #include <cryptopp/sha3.h>
 
 extern "C" {
-void SHA3_256(uint8_t *const ret, const uint8_t *data, size_t size) {
-  CryptoPP::SHA3_256().CalculateDigest(ret, data, size);
+struct ethash_blockhash;
+typedef struct ethash_blockhash ethash_blockhash_t;
+void SHA3_256(ethash_blockhash_t const* ret, const uint8_t *data, size_t size) {
+    CryptoPP::SHA3_256().CalculateDigest((uint8_t*)ret, data, size);
 }
 
 void SHA3_512(uint8_t *const ret, const uint8_t *data, size_t size) {

--- a/src/libethash/sha3_cryptopp.h
+++ b/src/libethash/sha3_cryptopp.h
@@ -2,12 +2,16 @@
 
 #include "compiler.h"
 #include <stdint.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-void SHA3_256(uint8_t *const ret, const uint8_t *data, size_t size);
+struct ethash_blockhash;
+typedef struct ethash_blockhash ethash_blockhash_t;
+
+void SHA3_256(ethash_blockhash_t *const ret, const uint8_t *data, size_t size);
 void SHA3_512(uint8_t *const ret, const uint8_t *data, size_t size);
 
 #ifdef __cplusplus

--- a/src/python/core.c
+++ b/src/python/core.c
@@ -110,7 +110,7 @@ calc_dataset_bytes(PyObject *self, PyObject *args) {
     free(mem);
     return val;
 }
-#define DEB(...) printf(__VA_ARGS__); fflush(stdout);
+
 // hashimoto_light(full_size, cache, header, nonce)
 static PyObject *
 hashimoto_light(PyObject *self, PyObject *args) {

--- a/src/python/core.c
+++ b/src/python/core.c
@@ -69,7 +69,7 @@ mkcache_bytes(PyObject *self, PyObject *args) {
     params.cache_size = (size_t) cache_size;
     ethash_cache cache;
     cache.mem = malloc(cache_size);
-    ethash_mkcache(&cache, &params, (uint8_t *) seed);
+    ethash_mkcache(&cache, &params, (ethash_blockhash_t *) seed);
     PyObject * val = Py_BuildValue(PY_STRING_FORMAT, cache.mem, cache_size);
     free(cache.mem);
     return val;
@@ -110,32 +110,29 @@ calc_dataset_bytes(PyObject *self, PyObject *args) {
     free(mem);
     return val;
 }
-
+#define DEB(...) printf(__VA_ARGS__); fflush(stdout);
 // hashimoto_light(full_size, cache, header, nonce)
 static PyObject *
 hashimoto_light(PyObject *self, PyObject *args) {
-    char *cache_bytes, *header;
+    char *cache_bytes;
+    char *header;
     unsigned long full_size;
     unsigned long long nonce;
     int cache_size, header_size;
-
     if (!PyArg_ParseTuple(args, "k" PY_STRING_FORMAT PY_STRING_FORMAT "K", &full_size, &cache_bytes, &cache_size, &header, &header_size, &nonce))
         return 0;
-
     if (full_size % MIX_WORDS != 0) {
         char error_message[1024];
         sprintf(error_message, "The size of data set must be a multiple of %i bytes (was %lu)", MIX_WORDS, full_size);
         PyErr_SetString(PyExc_ValueError, error_message);
         return 0;
     }
-
     if (cache_size % HASH_BYTES != 0) {
         char error_message[1024];
         sprintf(error_message, "The size of the cache must be a multiple of %i bytes (was %i)", HASH_BYTES, cache_size);
         PyErr_SetString(PyExc_ValueError, error_message);
         return 0;
     }
-
     if (header_size != 32) {
         char error_message[1024];
         sprintf(error_message, "Seed must be 32 bytes long (was %i)", header_size);
@@ -143,23 +140,23 @@ hashimoto_light(PyObject *self, PyObject *args) {
         return 0;
     }
 
-
     ethash_return_value out;
     ethash_params params;
     params.cache_size = (size_t) cache_size;
     params.full_size = (size_t) full_size;
     ethash_cache cache;
     cache.mem = (void *) cache_bytes;
-    ethash_light(&out, &cache, &params, (uint8_t *) header, nonce);
+    ethash_light(&out, &cache, &params, (ethash_blockhash_t *) header, nonce);
     return Py_BuildValue("{" PY_CONST_STRING_FORMAT ":" PY_STRING_FORMAT "," PY_CONST_STRING_FORMAT ":" PY_STRING_FORMAT "}",
-            "mix digest", out.mix_hash, 32,
-            "result", out.result, 32);
+                         "mix digest", &out.mix_hash, 32,
+                         "result", &out.result, 32);
 }
 
 // hashimoto_full(dataset, header, nonce)
 static PyObject *
 hashimoto_full(PyObject *self, PyObject *args) {
-    char *full_bytes, *header;
+    char *full_bytes;
+    char *header;
     unsigned long long nonce;
     int full_size, header_size;
 
@@ -184,16 +181,18 @@ hashimoto_full(PyObject *self, PyObject *args) {
     ethash_return_value out;
     ethash_params params;
     params.full_size = (size_t) full_size;
-    ethash_full(&out, (void *) full_bytes, &params, (uint8_t *) header, nonce);
+    ethash_full(&out, (void *) full_bytes, &params, (ethash_blockhash_t *) header, nonce);
     return Py_BuildValue("{" PY_CONST_STRING_FORMAT ":" PY_STRING_FORMAT ", " PY_CONST_STRING_FORMAT ":" PY_STRING_FORMAT "}",
-            "mix digest", out.mix_hash, 32,
-            "result", out.result, 32);
+                         "mix digest", &out.mix_hash, 32,
+                         "result", &out.result, 32);
 }
 
 // mine(dataset_bytes, header, difficulty_bytes)
 static PyObject *
 mine(PyObject *self, PyObject *args) {
-    char *full_bytes, *header, *difficulty;
+    char *full_bytes;
+    char *header;
+    char *difficulty;
     srand(time(0));
     uint64_t nonce = ((uint64_t) rand()) << 32 | rand();
     int full_size, header_size, difficulty_size;
@@ -228,13 +227,13 @@ mine(PyObject *self, PyObject *args) {
 
     // TODO: Multi threading?
     do {
-        ethash_full(&out, (void *) full_bytes, &params, (const uint8_t *) header, nonce++);
+        ethash_full(&out, (void *) full_bytes, &params, (const ethash_blockhash_t *) header, nonce++);
         // TODO: disagrees with the spec https://github.com/ethereum/wiki/wiki/Ethash#mining
-    } while (!ethash_check_difficulty(out.result, (const uint8_t *) difficulty));
+    } while (!ethash_check_difficulty(&out.result, (const ethash_blockhash_t *) difficulty));
 
     return Py_BuildValue("{" PY_CONST_STRING_FORMAT ":" PY_STRING_FORMAT ", " PY_CONST_STRING_FORMAT ":" PY_STRING_FORMAT ", " PY_CONST_STRING_FORMAT ":K}",
-            "mix digest", out.mix_hash, 32,
-            "result", out.result, 32,
+            "mix digest", &out.mix_hash, 32,
+            "result", &out.result, 32,
             "nonce", nonce);
 }
 
@@ -252,8 +251,8 @@ get_seedhash(PyObject *self, PyObject *args) {
         return 0;
     }
     ethash_blockhash_t seedhash;
-    ethash_get_seedhash(seedhash, block_number);
-    return Py_BuildValue(PY_STRING_FORMAT, (char *) seedhash, 32);
+    ethash_get_seedhash(&seedhash, block_number);
+    return Py_BuildValue(PY_STRING_FORMAT, (char *) &seedhash, 32);
 }
 
 static PyMethodDef PyethashMethods[] =

--- a/src/python/core.c
+++ b/src/python/core.c
@@ -251,7 +251,7 @@ get_seedhash(PyObject *self, PyObject *args) {
         PyErr_SetString(PyExc_ValueError, error_message);
         return 0;
     }
-    uint8_t seedhash[32];
+    ethash_blockhash_t seedhash;
     ethash_get_seedhash(seedhash, block_number);
     return Py_BuildValue(PY_STRING_FORMAT, (char *) seedhash, 32);
 }

--- a/test/python/test.sh
+++ b/test/python/test.sh
@@ -3,6 +3,13 @@
 # Strict mode
 set -e
 
+# just a specific case for archlinux where python3 is the default
+if [ -f "/etc/arch-release" ]; then
+    VIRTUALENV_EXEC=virtualenv2
+else
+    VIRTUALENV_EXEC=virtualenv
+fi
+
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do
   DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
@@ -11,9 +18,11 @@ while [ -h "$SOURCE" ]; do
 done
 TEST_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
-[ -d $TEST_DIR/python-virtual-env ] || virtualenv --system-site-packages $TEST_DIR/python-virtual-env
+[ -d $TEST_DIR/python-virtual-env ] || $VIRTUALENV_EXEC --system-site-packages $TEST_DIR/python-virtual-env
 source $TEST_DIR/python-virtual-env/bin/activate
 pip install -r $TEST_DIR/requirements.txt > /dev/null
+# force installation of nose in virtualenv even if existing in thereuser's system
+pip install nose -I
 pip install --upgrade --no-deps --force-reinstall -e $TEST_DIR/../..
 cd $TEST_DIR
 nosetests --with-doctest -v --nocapture

--- a/test/python/test.sh
+++ b/test/python/test.sh
@@ -3,11 +3,13 @@
 # Strict mode
 set -e
 
-# just a specific case for archlinux where python3 is the default
-if [ -f "/etc/arch-release" ]; then
-    VIRTUALENV_EXEC=virtualenv2
+if [ -x "$(which virtualenv2)" ] ; then
+   VIRTUALENV_EXEC=virtualenv2
+elif [ -x "$(which virtualenv)" ] ; then
+   VIRTUALENV_EXEC=virtualenv
 else
-    VIRTUALENV_EXEC=virtualenv
+   echo "Could not find a suitable version of virtualenv"
+   false
 fi
 
 SOURCE="${BASH_SOURCE[0]}"


### PR DESCRIPTION
Depends on #11.

- Using a typedef struct instead of passing an array of hard coded
  length of 32 bytes everywhere. It's much better C practise and also
  gives us typechecking.

- Also corrected style in places I touched. I think a style PR should
  follow after that.