### PR TITLE
Windows msvc build fix

### DIFF
--- a/src/libethash/io.h
+++ b/src/libethash/io.h
@@ -32,7 +32,8 @@ typedef struct ethash_blockhash { uint8_t b[32]; } ethash_blockhash_t;
 
 static const char DAG_FILE_NAME[] = "full";
 static const char DAG_MEMO_NAME[] = "full.info";
-static const unsigned int DAG_MEMO_BYTESIZE = 36;
+// MSVC thinks that "static const unsigned int" is not a compile time variable. Sorry for the #define :(
+#define DAG_MEMO_BYTESIZE 36
 
 /// Possible return values of @see ethash_io_prepare
 enum ethash_io_rc {

--- a/test/c/CMakeLists.txt
+++ b/test/c/CMakeLists.txt
@@ -1,5 +1,5 @@
 IF( NOT Boost_FOUND )
-    find_package(Boost 1.48.0 REQUIRED COMPONENTS unit_test_framework system filesystem)
+    find_package(Boost 1.48.0 COMPONENTS unit_test_framework system filesystem)
 ENDIF()
 
 IF( Boost_FOUND )


### PR DESCRIPTION
This should fix the windows build for msvc.

Basically if boost is not found simply don't run the C tests.