### PR TITLE
Memory mapped I/O

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,36 @@
 #!/usr/bin/env python
+import os
 from distutils.core import setup, Extension
-
+sources = [
+    'src/python/core.c',
+    'src/libethash/io.c',
+    'src/libethash/util.c',
+    'src/libethash/internal.c',
+    'src/libethash/sha3.c']
+if os.name == 'nt':
+    sources += [
+        'src/libethash/io_win32.c',
+        'src/libethash/mmap_win32.c',
+    ]
+else:
+    sources += [
+        'src/libethash/io_posix.c'
+    ]
+depends = [
+    'src/libethash/ethash.h',
+    'src/libethash/compiler.h',
+    'src/libethash/data_sizes.h',
+    'src/libethash/endian.h',
+    'src/libethash/ethash.h',
+    'src/libethash/io.h',
+    'src/libethash/fnv.h',
+    'src/libethash/internal.h',
+    'src/libethash/sha3.h',
+    'src/libethash/util.h',
+]
 pyethash = Extension('pyethash',
-                     sources=[
-                         'src/python/core.c',
-                         'src/libethash/util.c',
-                         'src/libethash/internal.c',
-                         'src/libethash/sha3.c'],
-                     depends=[
-                         'src/libethash/ethash.h',
-                         'src/libethash/compiler.h',
-                         'src/libethash/data_sizes.h',
-                         'src/libethash/endian.h',
-                         'src/libethash/ethash.h',
-                         'src/libethash/fnv.h',
-                         'src/libethash/internal.h',
-                         'src/libethash/sha3.h',
-                         'src/libethash/util.h'
-                     ],
+                     sources=sources,
+                     depends=depends,
                      extra_compile_args=["-Isrc/", "-std=gnu99", "-Wall"])
 
 setup(

--- a/src/libethash/CMakeLists.txt
+++ b/src/libethash/CMakeLists.txt
@@ -21,7 +21,7 @@ set(FILES 	util.c
           	data_sizes.h)
 
 if (MSVC)
-	list(APPEND FILES io_win32.c)
+	list(APPEND FILES io_win32.c mmap_win32.c)
 else()
 	list(APPEND FILES io_posix.c)
 endif()

--- a/src/libethash/ethash.h
+++ b/src/libethash/ethash.h
@@ -57,12 +57,12 @@ static inline uint8_t ethash_h256_get(ethash_h256_t const* hash, unsigned int i)
 	return hash->b[i];
 }
 
-static inline void ethash_h256_set(ethash_h256_t *hash, unsigned int i, uint8_t v)
+static inline void ethash_h256_set(ethash_h256_t* hash, unsigned int i, uint8_t v)
 {
 	hash->b[i] = v;
 }
 
-static inline void ethash_h256_reset(ethash_h256_t *hash)
+static inline void ethash_h256_reset(ethash_h256_t* hash)
 {
 	memset(hash, 0, 32);
 }
@@ -91,7 +91,7 @@ uint64_t ethash_get_datasize(const uint32_t block_number);
 uint64_t ethash_get_cachesize(const uint32_t block_number);
 
 // initialize the parameters
-static inline void ethash_params_init(ethash_params *params, const uint32_t block_number) {
+static inline void ethash_params_init(ethash_params* params, const uint32_t block_number) {
 	params->full_size = ethash_get_datasize(block_number);
 	params->cache_size = ethash_get_cachesize(block_number);
 }
@@ -111,12 +111,12 @@ typedef struct ethash_cache {
  * @return          Newly allocated ethash_cache on success or NULL in case of
  *                  ERRNOMEM or invalid parameters used for @ref ethash_compute_cache_nodes()
  */
-ethash_cache *ethash_cache_new(ethash_params const *params, ethash_h256_t const *seed);
+ethash_cache *ethash_cache_new(ethash_params const* params, ethash_h256_t const* seed);
 /**
  * Frees a previously allocated ethash_cache
  * @param c            The object to free
  */
-void ethash_cache_delete(ethash_cache *c);
+void ethash_cache_delete(ethash_cache* c);
 
 /**
  * Allocate and initialize a new ethash_light handler
@@ -128,7 +128,7 @@ void ethash_cache_delete(ethash_cache *c);
  * @return          Newly allocated ethash_light handler or NULL in case of
  *                  ERRNOMEM or invalid parameters used for @ref ethash_compute_cache_nodes()
  */
-ethash_light_t ethash_light_new(ethash_params const *params, ethash_h256_t const *seed);
+ethash_light_t ethash_light_new(ethash_params const* params, ethash_h256_t const* seed);
 /**
  * Frees a previously allocated ethash_light handler
  * @param light        The light handler to free
@@ -145,11 +145,11 @@ void ethash_light_delete(ethash_light_t light);
  * @return               true if all went well and false if there were invalid
  *                       parameters given.
  */
-bool ethash_light_compute(ethash_return_value *ret,
-						  ethash_light_t light,
-						  ethash_params const *params,
-						  const ethash_h256_t *header_hash,
-						  const uint64_t nonce);
+bool ethash_light_compute(ethash_return_value* ret,
+	ethash_light_t light,
+	ethash_params const* params,
+	const ethash_h256_t* header_hash,
+	const uint64_t nonce);
 /**
  * Get a pointer to the cache object held by the light client
  *
@@ -185,8 +185,8 @@ ethash_cache *ethash_light_acquire_cache(ethash_light_t light);
  * @return          Newly allocated ethash_full handler or NULL in case of
  *                  ERRNOMEM or invalid parameters used for @ref ethash_compute_full_data()
  */
-ethash_full_t ethash_full_new(char const *dirname,
-	const ethash_h256_t *seed_hash,
+ethash_full_t ethash_full_new(char const* dirname,
+	ethash_h256_t const* seed_hash,
 	ethash_params const* params,
 	ethash_cache const* cache,
 	ethash_callback_t callback);
@@ -207,11 +207,11 @@ void ethash_full_delete(ethash_full_t full);
  *                       parameters given or if there was a callback given and
  *                       at some point return a non-zero value
  */
-bool ethash_full_compute(ethash_return_value *ret,
-						 ethash_full_t full,
-						 ethash_params const *params,
-						 const ethash_h256_t *header_hash,
-						 const uint64_t nonce);
+bool ethash_full_compute(ethash_return_value* ret,
+	ethash_full_t full,
+	ethash_params const* params,
+	const ethash_h256_t* header_hash,
+	const uint64_t nonce);
 /**
  * Get a pointer to the cache object held by the full client
  *
@@ -232,8 +232,8 @@ ethash_cache *ethash_full_acquire_cache(ethash_full_t full);
 void ethash_get_seedhash(ethash_h256_t *seedhash, const uint32_t block_number);
 
 // Returns if hash is less than or equal to difficulty
-static inline int ethash_check_difficulty(ethash_h256_t const *hash,
-										  ethash_h256_t const *difficulty)
+static inline int ethash_check_difficulty(ethash_h256_t const* hash,
+	ethash_h256_t const* difficulty)
 {
 	// Difficulty is big endian
 	for (int i = 0; i < 32; i++) {
@@ -245,10 +245,10 @@ static inline int ethash_check_difficulty(ethash_h256_t const *hash,
 	return 1;
 }
 
-int ethash_quick_check_difficulty(ethash_h256_t const *header_hash,
-								  const uint64_t nonce,
-								  ethash_h256_t const *mix_hash,
-								  ethash_h256_t const *difficulty);
+int ethash_quick_check_difficulty(ethash_h256_t const* header_hash,
+	const uint64_t nonce,
+	ethash_h256_t const* mix_hash,
+	ethash_h256_t const* difficulty);
 
 
 /**
@@ -259,17 +259,17 @@ int ethash_quick_check_difficulty(ethash_h256_t const *header_hash,
  * Kept for backwards compatibility with whoever still uses it. Please consider
  * switching to the new API (look above)
  */
-void ethash_mkcache(ethash_cache *cache, ethash_params const *params, ethash_h256_t const *seed);
-void ethash_full(ethash_return_value *ret,
-				 void const *full_mem,
-				 ethash_params const *params,
-				 ethash_h256_t const *header_hash,
-				 const uint64_t nonce);
-void ethash_light(ethash_return_value *ret,
-				  ethash_cache const *cache,
-				  ethash_params const *params,
-				  ethash_h256_t const *header_hash,
-				  const uint64_t nonce);
+void ethash_mkcache(ethash_cache* cache, ethash_params const* params, ethash_h256_t const* seed);
+void ethash_full(ethash_return_value* ret,
+	void const* full_mem,
+	ethash_params const* params,
+	ethash_h256_t const* header_hash,
+	const uint64_t nonce);
+void ethash_light(ethash_return_value* ret,
+	ethash_cache const* cache,
+	ethash_params const* params,
+	ethash_h256_t const* header_hash,
+	const uint64_t nonce);
 /**
  * Compute the memory data for a full node's memory
  *
@@ -278,7 +278,7 @@ void ethash_light(ethash_return_value *ret,
  * @param cache       A cache object to use in the calculation
  * @return            true if all went fine and false for invalid parameters
  */
-bool ethash_compute_full_data(void *mem, ethash_params const *params, ethash_cache const *cache);
+bool ethash_compute_full_data(void* mem, ethash_params const* params, ethash_cache const* cache);
 
 #ifdef __cplusplus
 }

--- a/src/libethash/ethash.h
+++ b/src/libethash/ethash.h
@@ -73,7 +73,7 @@ static inline void ethash_h256_reset(ethash_h256_t *hash)
 // have to provide all 32 values. If you don't provide all the rest
 // will simply be unitialized (not guranteed to be 0)
 #define ethash_h256_static_init(...)			\
-	{.b = {__VA_ARGS__} }
+	{ {__VA_ARGS__} }
 
 struct ethash_light;
 typedef struct ethash_light* ethash_light_t;

--- a/src/libethash/ethash.h
+++ b/src/libethash/ethash.h
@@ -170,6 +170,8 @@ ethash_cache *ethash_light_acquire_cache(ethash_light_t light);
 /**
  * Allocate and initialize a new ethash_full handler
  *
+ * @param dirname   The directory in which to put the DAG file.
+ * @param seedhash  The seed hash of the block. Used in the DAG file naming.
  * @param params    The parameters to initialize it with. We are interested in
  *                  the full_size from here
  * @param cache     A cache object to use that was allocated with @ref ethash_cache_new().
@@ -183,9 +185,11 @@ ethash_cache *ethash_light_acquire_cache(ethash_light_t light);
  * @return          Newly allocated ethash_full handler or NULL in case of
  *                  ERRNOMEM or invalid parameters used for @ref ethash_compute_full_data()
  */
-ethash_full_t ethash_full_new(ethash_params const* params,
-							  ethash_cache const* cache,
-							  ethash_callback_t callback);
+ethash_full_t ethash_full_new(char const *dirname,
+	const ethash_h256_t *seed_hash,
+	ethash_params const* params,
+	ethash_cache const* cache,
+	ethash_callback_t callback);
 /**
  * Frees a previously allocated ethash_full handler
  * @param full    The light handler to free
@@ -198,7 +202,7 @@ void ethash_full_delete(ethash_full_t full);
  * @param full           The full client handler
  * @param params         The parameters to use
  * @param header_hash    The header hash to pack into the mix
- * @param nonce              The nonce to pack into the mix
+ * @param nonce          The nonce to pack into the mix
  * @return               true if all went well and false if there were invalid
  *                       parameters given or if there was a callback given and
  *                       at some point return a non-zero value

--- a/src/libethash/internal.c
+++ b/src/libethash/internal.c
@@ -371,12 +371,13 @@ ethash_full_t ethash_full_new(char const *dirname,
 	ret->file_size = (size_t)params->full_size;
 	switch (ethash_io_prepare(dirname, *seed_hash, &f, (size_t)params->full_size)) {
 	case ETHASH_IO_FAIL:
+	case ETHASH_IO_MEMO_SIZE_MISMATCH:
 		goto fail_free_full;
 	case ETHASH_IO_MEMO_MATCH:
 		match = true;
 	case ETHASH_IO_MEMO_MISMATCH:
 		ret->file = f;
-		if ((fd = fileno(ret->file)) == -1) {
+		if ((fd = ethash_fileno(ret->file)) == -1) {
 			goto fail_free_full;
 		}
 		ret->data = mmap(

--- a/src/libethash/internal.c
+++ b/src/libethash/internal.c
@@ -54,9 +54,9 @@ uint64_t ethash_get_cachesize(const uint32_t block_number) {
 // Follows Sergio's "STRICT MEMORY HARD HASHING FUNCTIONS" (2014)
 // https://bitslog.files.wordpress.com/2013/12/memohash-v0-3.pdf
 // SeqMemoHash(s, R, N)
-bool static ethash_compute_cache_nodes(node *const nodes,
-									   ethash_params const *params,
-									   ethash_h256_t const* seed)
+bool static ethash_compute_cache_nodes(node* const nodes,
+	ethash_params const* params,
+	ethash_h256_t const* seed)
 {
 	if (params->cache_size % sizeof(node) != 0) {
 		return false;
@@ -86,7 +86,7 @@ bool static ethash_compute_cache_nodes(node *const nodes,
 	return true;
 }
 
-ethash_cache *ethash_cache_new(ethash_params const *params, ethash_h256_t const *seed)
+ethash_cache *ethash_cache_new(ethash_params const* params, ethash_h256_t const* seed)
 {
 	ethash_cache *ret;
 	ret = malloc(sizeof(*ret));
@@ -111,16 +111,16 @@ fail_free_cache:
 	return NULL;
 }
 
-void ethash_cache_delete(ethash_cache *c)
+void ethash_cache_delete(ethash_cache* c)
 {
 	free(c->mem);
 	free(c);
 }
 
-void ethash_calculate_dag_item(node *const ret,
-							   const unsigned node_index,
-							   const struct ethash_params *params,
-							   const struct ethash_cache *cache)
+void ethash_calculate_dag_item(node* const ret,
+	const unsigned node_index,
+	const struct ethash_params *params,
+	const struct ethash_cache *cache)
 {
 	uint32_t num_parent_nodes = (uint32_t) (params->cache_size / sizeof(node));
 	node const *cache_nodes = (node const *) cache->mem;
@@ -169,9 +169,9 @@ void ethash_calculate_dag_item(node *const ret,
 	SHA3_512(ret->bytes, ret->bytes, sizeof(node));
 }
 
-bool ethash_compute_full_data(void *mem,
-							  ethash_params const *params,
-							  ethash_cache const *cache)
+bool ethash_compute_full_data(void* mem,
+	ethash_params const* params,
+	ethash_cache const* cache)
 {
 	if (params->full_size % (sizeof(uint32_t) * MIX_WORDS) != 0 ||
 		(params->full_size % sizeof(node)) != 0) {
@@ -185,13 +185,13 @@ bool ethash_compute_full_data(void *mem,
 	return true;
 }
 
-static bool ethash_hash(ethash_return_value *ret,
-						node const *full_nodes,
-						ethash_cache const *cache,
-						ethash_params const *params,
-						ethash_h256_t const *header_hash,
-						const uint64_t nonce,
-						ethash_callback_t callback)
+static bool ethash_hash(ethash_return_value* ret,
+	node const* full_nodes,
+	ethash_cache const* cache,
+	ethash_params const* params,
+	ethash_h256_t const* header_hash,
+	const uint64_t nonce,
+	ethash_callback_t callback)
 {
 	if (params->full_size % MIX_WORDS != 0) {
 		return false;
@@ -275,10 +275,10 @@ static bool ethash_hash(ethash_return_value *ret,
 	return true;
 }
 
-void ethash_quick_hash(ethash_h256_t *return_hash,
-					   ethash_h256_t const *header_hash,
-					   const uint64_t nonce,
-					   ethash_h256_t const *mix_hash)
+void ethash_quick_hash(ethash_h256_t* return_hash,
+	ethash_h256_t const* header_hash,
+	const uint64_t nonce,
+	ethash_h256_t const* mix_hash)
 {
 	uint8_t buf[64 + 32];
 	memcpy(buf, header_hash, 32);
@@ -289,7 +289,7 @@ void ethash_quick_hash(ethash_h256_t *return_hash,
 	SHA3_256(return_hash, buf, 64 + 32);
 }
 
-void ethash_get_seedhash(ethash_h256_t *seedhash, const uint32_t block_number)
+void ethash_get_seedhash(ethash_h256_t* seedhash, const uint32_t block_number)
 {
 	ethash_h256_reset(seedhash);
 	const uint32_t epochs = block_number / EPOCH_LENGTH;
@@ -297,10 +297,10 @@ void ethash_get_seedhash(ethash_h256_t *seedhash, const uint32_t block_number)
 		SHA3_256(seedhash, (uint8_t*)seedhash, 32);
 }
 
-int ethash_quick_check_difficulty(ethash_h256_t const *header_hash,
-								  const uint64_t nonce,
-								  ethash_h256_t const *mix_hash,
-								  ethash_h256_t const *difficulty)
+int ethash_quick_check_difficulty(ethash_h256_t const* header_hash,
+	const uint64_t nonce,
+	ethash_h256_t const* mix_hash,
+	ethash_h256_t const* difficulty)
 {
 
 	ethash_h256_t return_hash;
@@ -308,7 +308,7 @@ int ethash_quick_check_difficulty(ethash_h256_t const *header_hash,
 	return ethash_check_difficulty(&return_hash, difficulty);
 }
 
-ethash_light_t ethash_light_new(ethash_params const *params, ethash_h256_t const *seed)
+ethash_light_t ethash_light_new(ethash_params const* params, ethash_h256_t const* seed)
 {
 	struct ethash_light *ret;
 	ret = calloc(sizeof(*ret), 1);
@@ -335,10 +335,10 @@ void ethash_light_delete(ethash_light_t light)
 }
 
 bool ethash_light_compute(ethash_return_value *ret,
-						  ethash_light_t light,
-						  ethash_params const *params,
-						  const ethash_h256_t *header_hash,
-						  const uint64_t nonce)
+	ethash_light_t light,
+	ethash_params const* params,
+	const ethash_h256_t* header_hash,
+	const uint64_t nonce)
 {
 	return ethash_hash(ret, NULL, light->cache, params, header_hash, nonce, NULL);
 }
@@ -355,8 +355,8 @@ ethash_cache *ethash_light_acquire_cache(ethash_light_t light)
 	return ret;
 }
 
-ethash_full_t ethash_full_new(char const *dirname,
-	const ethash_h256_t *seed_hash,
+ethash_full_t ethash_full_new(char const* dirname,
+	ethash_h256_t const* seed_hash,
 	ethash_params const* params,
 	ethash_cache const* cache,
 	ethash_callback_t callback)
@@ -429,11 +429,11 @@ void ethash_full_delete(ethash_full_t full)
 	free(full);
 }
 
-bool ethash_full_compute(ethash_return_value *ret,
-						 ethash_full_t full,
-						 ethash_params const *params,
-						 const ethash_h256_t *header_hash,
-						 const uint64_t nonce)
+bool ethash_full_compute(ethash_return_value* ret,
+	ethash_full_t full,
+	ethash_params const* params,
+	const ethash_h256_t* header_hash,
+	const uint64_t nonce)
 {
 	return ethash_hash(ret,
 					   (node const*)full->data,
@@ -464,25 +464,25 @@ ethash_cache *ethash_full_acquire_cache(ethash_full_t full)
  * Kept for backwards compatibility with whoever still uses it. Please consider
  * switching to the new API (look above)
  */
-void ethash_mkcache(ethash_cache *cache,
-					ethash_params const *params,
+void ethash_mkcache(ethash_cache* cache,
+					ethash_params const* params,
 					ethash_h256_t const* seed)
 {
 	node *nodes = (node*) cache->mem;
 	ethash_compute_cache_nodes(nodes, params, seed);
 }
-void ethash_full(ethash_return_value *ret,
-				 void const *full_mem,
-				 ethash_params const *params,
-				 ethash_h256_t const *header_hash,
+void ethash_full(ethash_return_value* ret,
+				 void const* full_mem,
+				 ethash_params const* params,
+				 ethash_h256_t const* header_hash,
 				 const uint64_t nonce)
 {
 	ethash_hash(ret, (node const *) full_mem, NULL, params, header_hash, nonce, NULL);
 }
 void ethash_light(ethash_return_value *ret,
-				  ethash_cache const *cache,
-				  ethash_params const *params,
-				  ethash_h256_t const *header_hash,
+				  ethash_cache const* cache,
+				  ethash_params const* params,
+				  ethash_h256_t const* header_hash,
 				  const uint64_t nonce)
 {
 	ethash_hash(ret, NULL, cache, params, header_hash, nonce, NULL);

--- a/src/libethash/internal.h
+++ b/src/libethash/internal.h
@@ -37,6 +37,7 @@ struct ethash_light {
 
 struct ethash_full {
 	FILE *file;
+	size_t file_size;
 	ethash_cache *cache;
 	node *data;
 	ethash_callback_t callback;

--- a/src/libethash/io.c
+++ b/src/libethash/io.c
@@ -48,3 +48,61 @@ free_name:
 	free(fullname);
 	return ret;
 }
+
+enum ethash_io_rc ethash_io_prepare(char const *dirname,
+	ethash_h256_t const seedhash,
+	FILE **output_file,
+	size_t file_size)
+{
+	char mutable_name[DAG_MUTABLE_NAME_MAX_SIZE];
+	enum ethash_io_rc ret = ETHASH_IO_FAIL;
+
+	// assert directory exists
+	if (!ethash_mkdir(dirname)) {
+		goto end;
+	}
+
+	ethash_io_mutable_name(REVISION, &seedhash, mutable_name);
+	char *tmpfile = ethash_io_create_filename(dirname, mutable_name, strlen(mutable_name));
+	if (!tmpfile) {
+		goto end;
+	}
+
+	// try to open the file
+	FILE *f = ethash_fopen(tmpfile, "rb+");
+	if (f) {
+		size_t found_size;
+		if (!ethash_file_size(f, &found_size)) {
+			fclose(f);
+			goto free_memo;
+		}
+		if (file_size != found_size) {
+			fclose(f);
+			ret = ETHASH_IO_MEMO_SIZE_MISMATCH;
+			goto free_memo;
+		}
+	} else {
+		// file does not exist, will need to be created
+		f = ethash_fopen(tmpfile, "wb+");
+		if (!f) {
+			goto free_memo;
+		}
+		// make sure it's of the proper size
+		if (fseek(f, file_size - 1, SEEK_SET) != 0) {
+			fclose(f);
+			goto free_memo;
+		}
+		fputc('\n', f);
+		fflush(f);
+		ret = ETHASH_IO_MEMO_MISMATCH;
+		goto set_file;
+	}
+
+	ret = ETHASH_IO_MEMO_MATCH;
+set_file:
+	*output_file = f;
+free_memo:
+	free(tmpfile);
+end:
+	return ret;
+}

--- a/src/libethash/io.h
+++ b/src/libethash/io.h
@@ -43,6 +43,12 @@ enum ethash_io_rc {
 	ETHASH_IO_MEMO_MATCH,         ///< DAG file existed and revision/hash matched. No need to do anything
 };
 
+// small hack for windows. I don't feel I should use va_args and forward just
+// to have this one function properly cross-platform abstracted
+#if defined(_WIN32)
+#define snprintf(...) sprintf_s(__VA_ARGS__)
+#endif
+
 /**
  * Prepares io for ethash
  *

--- a/src/libethash/io.h
+++ b/src/libethash/io.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <inttypes.h>
 #include "endian.h"
 #include "ethash.h"
 
@@ -138,7 +139,7 @@ static inline bool ethash_io_mutable_name(uint32_t revision,
 #if LITTLE_ENDIAN == BYTE_ORDER
     hash = ethash_swap_u64(hash);
 #endif
-    return snprintf(output, DAG_MUTABLE_NAME_MAX_SIZE, "%u_%016lx", revision, hash) >= 0;
+    return snprintf(output, DAG_MUTABLE_NAME_MAX_SIZE, "%u_%016" PRIx64, revision, hash) >= 0;
 }
 
 static inline char *ethash_io_create_filename(char const* dirname,

--- a/src/libethash/io.h
+++ b/src/libethash/io.h
@@ -37,9 +37,10 @@ extern "C" {
 #define DAG_MUTABLE_NAME_MAX_SIZE (10 + 1 + 16 + 1)
 /// Possible return values of @see ethash_io_prepare
 enum ethash_io_rc {
-	ETHASH_IO_FAIL = 0,      ///< There has been an IO failure
-	ETHASH_IO_MEMO_MISMATCH, ///< The DAG file did not exist or there was revision/hash mismatch
-	ETHASH_IO_MEMO_MATCH,    ///< DAG file existed and revision/hash matched. No need to do anything
+	ETHASH_IO_FAIL = 0,           ///< There has been an IO failure
+	ETHASH_IO_MEMO_SIZE_MISMATCH, ///< DAG with revision/hash match, but file size was wrong.
+	ETHASH_IO_MEMO_MISMATCH,      ///< The DAG file did not exist or there was revision/hash mismatch
+	ETHASH_IO_MEMO_MATCH,         ///< DAG file existed and revision/hash matched. No need to do anything
 };
 
 /**
@@ -78,6 +79,7 @@ enum ethash_io_rc ethash_io_prepare(char const *dirname,
  * @return                 The FILE* or NULL in failure
  */
 FILE *ethash_fopen(const char *file_name, const char *mode);
+
 /**
  * An strncat wrapper for no-warnings crossplatform strncat.
  *
@@ -95,6 +97,32 @@ FILE *ethash_fopen(const char *file_name, const char *mode);
  *                         error returns NULL
  */
 char *ethash_strncat(char *dest, size_t dest_size, const char *src, size_t count);
+
+/**
+ * A cross-platform mkdir wrapper to create a directory or assert it's there
+ * 
+ * @param dirname        The full path of the directory to create
+ * @return               true if the directory was created or if it already
+ *                       existed
+ */
+bool ethash_mkdir(char const *dirname);
+
+/**
+ * Get a file's size
+ *
+ * @param[in] f        The open file stream whose size to get
+ * @param[out] size    Pass a size_t by reference to contain the file size
+ * @return             true in success and false if there was a failure
+ */
+bool ethash_file_size(FILE *f, size_t *ret_size);
+
+/**
+ * Get a file descriptor number from a FILE stream
+ * 
+ * @param f            The file stream whose fd to get
+ * @return             Platform specific fd handler
+ */
+int ethash_fileno(FILE *f);
 
 static inline bool ethash_io_mutable_name(uint32_t revision,
 	ethash_h256_t const* seed_hash,

--- a/src/libethash/io.h
+++ b/src/libethash/io.h
@@ -23,6 +23,9 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
+#ifdef __cplusplus
+#define __STDC_FORMAT_MACROS 1
+#endif
 #include <inttypes.h>
 #include "endian.h"
 #include "ethash.h"

--- a/src/libethash/io_win32.c
+++ b/src/libethash/io_win32.c
@@ -35,50 +35,24 @@ char *ethash_strncat(char *dest, size_t dest_size, const char *src, size_t count
 	return strncat_s(dest, dest_size, src, count) == 0 ? dest : NULL;
 }
 
-enum ethash_io_rc ethash_io_prepare(char const *dirname,
-	ethash_h256_t const seedhash,
-	FILE **output_file,
-	size_t file_size)
+bool ethash_mkdir(char const *dirname)
 {
-	char mutable_name[DAG_MUTABLE_NAME_MAX_SIZE];
-	enum ethash_io_rc ret = ETHASH_IO_FAIL;
-
-	// assert directory exists
 	int rc = _mkdir(dirname);
-	if (rc == -1 && errno != EEXIST) {
-		goto end;
-	}
+	return rc != -1 || errno == EEXIST;
+}
 
-	ethash_io_mutable_name(REVISION, &seedhash, mutable_name);
-	char *tmpfile = ethash_io_create_filename(dirname, mutable_name, strlen(mutable_name));
-	if (!tmpfile) {
-		goto end;
-	}
+int ethash_fileno(FILE *f)
+{
+	return _fileno(f);
+}
 
-	// try to open the file
-	FILE *f = ethash_fopen(tmpfile, "rb+");
-	if (!f) {
-		// file does not exist, will need to be created
-		f = ethash_fopen(tmpfile, "wb+");
-		if (!f) {
-			goto free_memo;
-		}
-		// make sure it's of the proper size
-		if (fseek(f, file_size - 1, SEEK_SET) != 0) {
-			fclose(f);
-			goto free_memo;
-		}
-		fputc('\n', f);
-		fflush(f);
-		ret = ETHASH_IO_MEMO_MISMATCH;
-		goto set_file;
+bool ethash_file_size(FILE *f, size_t *ret_size)
+{
+	struct _stat st;
+	int fd;
+	if ((fd = _fileno(f)) == -1 || _fstat(fd, &st) != 0) {
+		return false;
 	}
-
-	ret = ETHASH_IO_MEMO_MATCH;
-set_file:
-	*output_file = f;
-free_memo:
-	free(tmpfile);
-end:
-	return ret;
+	*ret_size = st.st_size;
+	return true;
 }

--- a/src/libethash/io_win32.c
+++ b/src/libethash/io_win32.c
@@ -23,6 +23,8 @@
 #include <direct.h>
 #include <errno.h>
 #include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 FILE *ethash_fopen(const char *file_name, const char *mode)
 {

--- a/src/libethash/mmap.h
+++ b/src/libethash/mmap.h
@@ -39,6 +39,7 @@
 #define MAP_FAILED    ((void *) -1)
 
 void *mmap(void *start, size_t length, int prot, int flags, int fd, off_t offset);
+void munmap(void *addr, size_t length);
 #else // posix, yay! ^_^
 #include <sys/mman.h>
 #endif

--- a/src/libethash/mmap.h
+++ b/src/libethash/mmap.h
@@ -1,0 +1,28 @@
+/*
+  This file is part of ethash.
+
+  ethash is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  ethash is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with ethash.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/** @file mmap.h
+ * @author Lefteris Karapetsas <lefteris@ethdev.com>
+ * @date 2015
+ */
+#pragma once
+#if defined(__MINGW32__) || defined(_WIN32)
+void *mmap(void *start, size_t length, int prot, int flags, int fd, off_t offset);
+#else
+#include <sys/mman.h>
+#endif
+
+

--- a/src/libethash/mmap.h
+++ b/src/libethash/mmap.h
@@ -20,8 +20,26 @@
  */
 #pragma once
 #if defined(__MINGW32__) || defined(_WIN32)
-void *mmap(void *start, size_t length, int prot, int flags, int fd, off_t offset);
+#include <sys/types.h>
+
+#define PROT_READ     0x1
+#define PROT_WRITE    0x2
+/* This flag is only available in WinXP+ */
+#ifdef FILE_MAP_EXECUTE
+#define PROT_EXEC     0x4
 #else
+#define PROT_EXEC        0x0
+#define FILE_MAP_EXECUTE 0
+#endif
+
+#define MAP_SHARED    0x01
+#define MAP_PRIVATE   0x02
+#define MAP_ANONYMOUS 0x20
+#define MAP_ANON      MAP_ANONYMOUS
+#define MAP_FAILED    ((void *) -1)
+
+void *mmap(void *start, size_t length, int prot, int flags, int fd, off_t offset);
+#else // posix, yay! ^_^
 #include <sys/mman.h>
 #endif
 

--- a/src/libethash/mmap_win32.c
+++ b/src/libethash/mmap_win32.c
@@ -68,16 +68,16 @@ void *mmap(void *start, size_t length, int prot, int flags, int fd, off_t offset
 		dwDesiredAccess |= FILE_MAP_COPY;
 	void *ret = MapViewOfFile(h, dwDesiredAccess, DWORD_HI(offset), DWORD_LO(offset), length);
 	if (ret == NULL) {
-		CloseHandle(h);
 		ret = MAP_FAILED;
 	}
+	// since we are handling the file ourselves with fd, close the Windows Handle here
+	CloseHandle(h);
 	return ret;
 }
 
 void munmap(void *addr, size_t length)
 {
 	UnmapViewOfFile(addr);
-	/* ruh-ro, we leaked handle from CreateFileMapping() ... */
 }
 
 #undef DWORD_HI

--- a/src/libethash/mmap_win32.c
+++ b/src/libethash/mmap_win32.c
@@ -13,24 +13,7 @@
 
 #include <io.h>
 #include <windows.h>
-#include <sys/types.h>
 #include "mmap.h"
-
-#define PROT_READ     0x1
-#define PROT_WRITE    0x2
-/* This flag is only available in WinXP+ */
-#ifdef FILE_MAP_EXECUTE
-#define PROT_EXEC     0x4
-#else
-#define PROT_EXEC        0x0
-#define FILE_MAP_EXECUTE 0
-#endif
-
-#define MAP_SHARED    0x01
-#define MAP_PRIVATE   0x02
-#define MAP_ANONYMOUS 0x20
-#define MAP_ANON      MAP_ANONYMOUS
-#define MAP_FAILED    ((void *) -1)
 
 #ifdef __USE_FILE_OFFSET64
 # define DWORD_HI(x) (x >> 32)

--- a/src/libethash/mmap_win32.c
+++ b/src/libethash/mmap_win32.c
@@ -1,0 +1,101 @@
+/* mmap() replacement for Windows
+ *
+ * Author: Mike Frysinger <vapier@gentoo.org>
+ * Placed into the public domain
+ */
+
+/* References:
+ * CreateFileMapping: http://msdn.microsoft.com/en-us/library/aa366537(VS.85).aspx
+ * CloseHandle:       http://msdn.microsoft.com/en-us/library/ms724211(VS.85).aspx
+ * MapViewOfFile:     http://msdn.microsoft.com/en-us/library/aa366761(VS.85).aspx
+ * UnmapViewOfFile:   http://msdn.microsoft.com/en-us/library/aa366882(VS.85).aspx
+ */
+
+#include <io.h>
+#include <windows.h>
+#include <sys/types.h>
+#include "mmap.h"
+
+#define PROT_READ     0x1
+#define PROT_WRITE    0x2
+/* This flag is only available in WinXP+ */
+#ifdef FILE_MAP_EXECUTE
+#define PROT_EXEC     0x4
+#else
+#define PROT_EXEC        0x0
+#define FILE_MAP_EXECUTE 0
+#endif
+
+#define MAP_SHARED    0x01
+#define MAP_PRIVATE   0x02
+#define MAP_ANONYMOUS 0x20
+#define MAP_ANON      MAP_ANONYMOUS
+#define MAP_FAILED    ((void *) -1)
+
+#ifdef __USE_FILE_OFFSET64
+# define DWORD_HI(x) (x >> 32)
+# define DWORD_LO(x) ((x) & 0xffffffff)
+#else
+# define DWORD_HI(x) (0)
+# define DWORD_LO(x) (x)
+#endif
+
+void *mmap(void *start, size_t length, int prot, int flags, int fd, off_t offset)
+{
+	if (prot & ~(PROT_READ | PROT_WRITE | PROT_EXEC))
+		return MAP_FAILED;
+	if (fd == -1) {
+		if (!(flags & MAP_ANON) || offset)
+			return MAP_FAILED;
+	} else if (flags & MAP_ANON)
+		return MAP_FAILED;
+
+	DWORD flProtect;
+	if (prot & PROT_WRITE) {
+		if (prot & PROT_EXEC)
+			flProtect = PAGE_EXECUTE_READWRITE;
+		else
+			flProtect = PAGE_READWRITE;
+	} else if (prot & PROT_EXEC) {
+		if (prot & PROT_READ)
+			flProtect = PAGE_EXECUTE_READ;
+		else if (prot & PROT_EXEC)
+			flProtect = PAGE_EXECUTE;
+	} else
+		flProtect = PAGE_READONLY;
+
+	off_t end = length + offset;
+	HANDLE mmap_fd, h;
+	if (fd == -1)
+		mmap_fd = INVALID_HANDLE_VALUE;
+	else
+		mmap_fd = (HANDLE)_get_osfhandle(fd);
+	h = CreateFileMapping(mmap_fd, NULL, flProtect, DWORD_HI(end), DWORD_LO(end), NULL);
+	if (h == NULL)
+		return MAP_FAILED;
+
+	DWORD dwDesiredAccess;
+	if (prot & PROT_WRITE)
+		dwDesiredAccess = FILE_MAP_WRITE;
+	else
+		dwDesiredAccess = FILE_MAP_READ;
+	if (prot & PROT_EXEC)
+		dwDesiredAccess |= FILE_MAP_EXECUTE;
+	if (flags & MAP_PRIVATE)
+		dwDesiredAccess |= FILE_MAP_COPY;
+	void *ret = MapViewOfFile(h, dwDesiredAccess, DWORD_HI(offset), DWORD_LO(offset), length);
+	if (ret == NULL) {
+		CloseHandle(h);
+		ret = MAP_FAILED;
+	}
+	return ret;
+}
+
+static void munmap(void *addr, size_t length)
+{
+	UnmapViewOfFile(addr);
+	/* ruh-ro, we leaked handle from CreateFileMapping() ... */
+}
+
+#undef DWORD_HI
+#undef DWORD_LO

--- a/src/libethash/mmap_win32.c
+++ b/src/libethash/mmap_win32.c
@@ -74,7 +74,7 @@ void *mmap(void *start, size_t length, int prot, int flags, int fd, off_t offset
 	return ret;
 }
 
-static void munmap(void *addr, size_t length)
+void munmap(void *addr, size_t length)
 {
 	UnmapViewOfFile(addr);
 	/* ruh-ro, we leaked handle from CreateFileMapping() ... */

--- a/test/c/test.cpp
+++ b/test/c/test.cpp
@@ -157,14 +157,15 @@ BOOST_AUTO_TEST_CASE(test_ethash_dir_creation) {
 	memset(&seedhash, 0, 32);
 	BOOST_REQUIRE_EQUAL(
 		ETHASH_IO_MEMO_MISMATCH,
-		ethash_io_prepare("./test_ethash_directory/", seedhash, &f)
+		ethash_io_prepare("./test_ethash_directory/", seedhash, &f, 64)
 	);
-	BOOST_REQUIRE(!f);
+	BOOST_REQUIRE(f);
 
 	// let's make sure that the directory was created
 	BOOST_REQUIRE(fs::is_directory(fs::path("./test_ethash_directory/")));
 
 	// cleanup
+	fclose(f);
 	fs::remove_all("./test_ethash_directory/");
 }
 
@@ -172,35 +173,25 @@ BOOST_AUTO_TEST_CASE(test_ethash_io_memo_file_match) {
 	ethash_h256_t seedhash;
 	static const int blockn = 0;
 	FILE *f = NULL;
-	char mutable_name[DAG_MUTABLE_NAME_MAX_SIZE];
 	ethash_get_seedhash(&seedhash, blockn);
 	BOOST_REQUIRE_EQUAL(
 		ETHASH_IO_MEMO_MISMATCH,
-		ethash_io_prepare("./test_ethash_directory/", seedhash, &f)
+		ethash_io_prepare("./test_ethash_directory/", seedhash, &f, 64)
 	);
+	BOOST_REQUIRE(f);
+	fclose(f);
 
 	// let's make sure that the directory was created
 	BOOST_REQUIRE(fs::is_directory(fs::path("./test_ethash_directory/")));
-
-	// now create the file
-	ethash_io_mutable_name(REVISION, &seedhash, mutable_name);
-	char *tmpfile = ethash_io_create_filename("./test_ethash_directory/",
-		mutable_name,
-		strlen(mutable_name));
-	FILE *created_f = fopen(tmpfile, "wb");
-	BOOST_REQUIRE(fs::exists(fs::path(tmpfile)));
-	fclose(created_f);
-
 	// and check that we have a match when checking again
 	BOOST_REQUIRE_EQUAL(
 		ETHASH_IO_MEMO_MATCH,
-		ethash_io_prepare("./test_ethash_directory/", seedhash, &f)
+		ethash_io_prepare("./test_ethash_directory/", seedhash, &f, 64)
 	);
 	BOOST_REQUIRE(f);
 
 	// cleanup
 	fclose(f);
-	free(tmpfile);
 	fs::remove_all("./test_ethash_directory/");
 }
 
@@ -242,7 +233,13 @@ BOOST_AUTO_TEST_CASE(light_and_full_client_checks) {
 	ethash_light_t light = ethash_light_new(&params, &seed);
 	ethash_cache *cache = ethash_light_get_cache(light);
 	BOOST_ASSERT(light);
-	ethash_full_t full = ethash_full_new(&params, ethash_light_get_cache(light), NULL);
+	ethash_full_t full = ethash_full_new(
+		"./test_ethash_directory/",
+		&seed,
+		&params,
+		ethash_light_get_cache(light),
+		NULL
+	);
 	BOOST_ASSERT(full);
 	{
 		const std::string
@@ -253,8 +250,6 @@ BOOST_AUTO_TEST_CASE(light_and_full_client_checks) {
 				"\nexpected: " << expected.c_str() << "\n"
 						<< "actual: " << actual.c_str() << "\n");
 	}
-
-
 	{
 		node node;
 		ethash_calculate_dag_item(&node, 0, &params, cache);
@@ -265,7 +260,6 @@ BOOST_AUTO_TEST_CASE(light_and_full_client_checks) {
 				"\n" << "expected: " << expected.c_str() << "\n"
 						<< "actual: " << actual.c_str() << "\n");
 	}
-
 	{
 		for (int i = 0; i < params.full_size / sizeof(node); ++i) {
 			for (uint32_t j = 0; j < 32; ++j) {
@@ -281,7 +275,6 @@ BOOST_AUTO_TEST_CASE(light_and_full_client_checks) {
 			}
 		}
 	}
-
 	{
 		uint64_t nonce = 0x7c7c597c;
 		BOOST_REQUIRE(ethash_full_compute(&full_out, full, &params, &hash, nonce));
@@ -310,7 +303,6 @@ BOOST_AUTO_TEST_CASE(light_and_full_client_checks) {
 		std::string
 				light_result_string = blockhashToHexString(&light_out.result),
 				full_result_string = blockhashToHexString(&full_out.result);
-
 		BOOST_REQUIRE_MESSAGE(light_result_string != full_result_string,
 				"\nlight result and full result should differ: " << light_result_string.c_str() << "\n");
 
@@ -333,12 +325,12 @@ BOOST_AUTO_TEST_CASE(light_and_full_client_checks) {
 				"ethash_quick_check_difficulty failed"
 		);
 	}
-
 	// and at the end free the memory. Note that both light and full clients own
 	// the cache at this point so it's necessary to move ownership out of either
 	BOOST_REQUIRE(ethash_light_acquire_cache(light));
 	ethash_light_delete(light);
 	ethash_full_delete(full);
+	fs::remove_all("./test_ethash_directory/");
 }
 
 

--- a/test/c/test.cpp
+++ b/test/c/test.cpp
@@ -195,6 +195,30 @@ BOOST_AUTO_TEST_CASE(test_ethash_io_memo_file_match) {
 	fs::remove_all("./test_ethash_directory/");
 }
 
+BOOST_AUTO_TEST_CASE(test_ethash_io_memo_file_size_mismatch) {
+	ethash_h256_t seedhash;
+	static const int blockn = 0;
+	FILE *f = NULL;
+	ethash_get_seedhash(&seedhash, blockn);
+	BOOST_REQUIRE_EQUAL(
+		ETHASH_IO_MEMO_MISMATCH,
+		ethash_io_prepare("./test_ethash_directory/", seedhash, &f, 64)
+	);
+	BOOST_REQUIRE(f);
+	fclose(f);
+
+	// let's make sure that the directory was created
+	BOOST_REQUIRE(fs::is_directory(fs::path("./test_ethash_directory/")));
+	// and check that we get the size mismatch detected if we request diffferent size
+	BOOST_REQUIRE_EQUAL(
+		ETHASH_IO_MEMO_SIZE_MISMATCH,
+		ethash_io_prepare("./test_ethash_directory/", seedhash, &f, 65)
+	);
+
+	// cleanup
+	fs::remove_all("./test_ethash_directory/");
+}
+
 // could have used dev::contentsNew but don't wanna try to import
 // libdevcore just for one function
 static std::vector<char> readFileIntoVector(char const* filename)


### PR DESCRIPTION
Please Review:

- Adding mmap_win32.c, a wrapper of `CreateFileMapping()` for Windows to expose the good old same mmap() api we have in Posix.

- io_posix. and io_win32.c now contains the minimum amount of code possible.

- Fixed windows specific issues regarding printf format specifiers

- Tests and fixes regarding ethash_callback_t