### PR TITLE
Update paths so posix impl are consistent and windows isn't using wchar.

### DIFF
--- a/src/libethash/io_posix.c
+++ b/src/libethash/io_posix.c
@@ -26,10 +26,8 @@
 #include <libgen.h>
 #include <stdio.h>
 #include <unistd.h>
-#if defined(__APPLE__)
 #include <stdlib.h>
 #include <pwd.h>
-#endif
 
 FILE* ethash_fopen(char const* file_name, char const* mode)
 {
@@ -93,14 +91,12 @@ bool ethash_get_default_dirname(char* strbuf, size_t buffsize)
 	static const char dir_suffix[] = ".ethash/";
 	strbuf[0] = '\0';
 	char* home_dir = getenv("HOME");
-#if defined(__APPLE__)
 	if (!home_dir || strlen(home_dir) == 0)
 	{
 		struct passwd* pwd = getpwuid(getuid());
 		if (pwd)
 			home_dir = pwd->pw_dir;
 	}
-#endif
 	
 	size_t len = strlen(home_dir);
 	if (!ethash_strncat(strbuf, buffsize, home_dir, len)) {

--- a/src/libethash/io_posix.c
+++ b/src/libethash/io_posix.c
@@ -26,6 +26,10 @@
 #include <libgen.h>
 #include <stdio.h>
 #include <unistd.h>
+#if defined(__APPLE__)
+#include <stdlib.h>
+#include <pwd.h>
+#endif
 
 FILE* ethash_fopen(char const* file_name, char const* mode)
 {
@@ -89,6 +93,15 @@ bool ethash_get_default_dirname(char* strbuf, size_t buffsize)
 	static const char dir_suffix[] = ".ethash/";
 	strbuf[0] = '\0';
 	char* home_dir = getenv("HOME");
+#if defined(__APPLE__)
+	if (!home_dir || strlen(home_dir) == 0)
+	{
+		struct passwd* pwd = getpwuid(getuid());
+		if (pwd)
+			home_dir = pwd->pw_dir;
+	}
+#endif
+	
 	size_t len = strlen(home_dir);
 	if (!ethash_strncat(strbuf, buffsize, home_dir, len)) {
 		return false;

--- a/src/libethash/io_win32.c
+++ b/src/libethash/io_win32.c
@@ -87,9 +87,9 @@ bool ethash_file_size(FILE* f, size_t* ret_size)
 
 bool ethash_get_default_dirname(char* strbuf, size_t buffsize)
 {
-	static const char dir_suffix[] = "Appdata\\Ethash\\";
+	static const char dir_suffix[] = "Ethash\\";
 	strbuf[0] = '\0';
-	if (!SUCCEEDED(SHGetFolderPathW(NULL, CSIDL_PROFILE, NULL, 0, (WCHAR*)strbuf))) {
+	if (!SUCCEEDED(SHGetFolderPathA(NULL, CSIDL_LOCAL_APPDATA, NULL, 0, (CHAR*)strbuf))) {
 		return false;
 	}
 	if (!ethash_strncat(strbuf, buffsize, "\\", 1)) {


### PR DESCRIPTION
Calling SHGetFolderPathW would necessitate using wchar_t and some messy conversioning. Easier to just go with SHGetFolderPathA.