### PR TITLE
FreeBSD fix for ethash byte ordering

### DIFF
--- a/src/libethash/endian.h
+++ b/src/libethash/endian.h
@@ -32,6 +32,9 @@
 #include <libkern/OSByteOrder.h>
 #define ethash_swap_u32(input_) OSSwapInt32(input_)
 #define ethash_swap_u64(input_) OSSwapInt64(input_)
+#elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__)
+#define ethash_swap_u32(input_) bswap32(input_)
+#define ethash_swap_u64(input_) bswap64(input_)
 #else // posix
 #include <byteswap.h>
 #define ethash_swap_u32(input_) __bswap_32(input_)


### PR DESCRIPTION
Changes from https://github.com/ethereum/cpp-ethereum/pull/1919 . It closes https://github.com/ethereum/cpp-ethereum/issues/1918