### PR TITLE
quick_difficulty_check difficulty argument clarification

### DIFF
--- a/src/libethash/internal.c
+++ b/src/libethash/internal.c
@@ -284,13 +284,13 @@ bool ethash_quick_check_difficulty(
 	ethash_h256_t const* header_hash,
 	uint64_t const nonce,
 	ethash_h256_t const* mix_hash,
-	ethash_h256_t const* difficulty
+	ethash_h256_t const* boundary
 )
 {
 
 	ethash_h256_t return_hash;
 	ethash_quick_hash(&return_hash, header_hash, nonce, mix_hash);
-	return ethash_check_difficulty(&return_hash, difficulty);
+	return ethash_check_difficulty(&return_hash, boundary);
 }
 
 ethash_light_t ethash_light_new_internal(uint64_t cache_size, ethash_h256_t const* seed)

--- a/src/libethash/internal.h
+++ b/src/libethash/internal.h
@@ -46,27 +46,36 @@ static inline void ethash_h256_reset(ethash_h256_t* hash)
 	memset(hash, 0, 32);
 }
 
-// Returns if hash is less than or equal to difficulty
+// Returns if hash is less than or equal to boundary (2^256/difficulty)
 static inline bool ethash_check_difficulty(
 	ethash_h256_t const* hash,
-	ethash_h256_t const* difficulty
+	ethash_h256_t const* boundary
 )
 {
-	// Difficulty is big endian
+	// Boundary is big endian
 	for (int i = 0; i < 32; i++) {
-		if (ethash_h256_get(hash, i) == ethash_h256_get(difficulty, i)) {
+		if (ethash_h256_get(hash, i) == ethash_h256_get(boundary, i)) {
 			continue;
 		}
-		return ethash_h256_get(hash, i) < ethash_h256_get(difficulty, i);
+		return ethash_h256_get(hash, i) < ethash_h256_get(boundary, i);
 	}
 	return true;
 }
 
+/**
+ *  Difficulty quick check for POW preverification
+ *
+ * @param header_hash      The hash of the header
+ * @param nonce            The block's nonce
+ * @param mix_hash         The mix digest hash
+ * @param boundary         The boundary is defined as (2^256 / difficulty)
+ * @return                 true for succesful pre-verification and false otherwise
+ */
 bool ethash_quick_check_difficulty(
 	ethash_h256_t const* header_hash,
 	uint64_t const nonce,
 	ethash_h256_t const* mix_hash,
-	ethash_h256_t const* difficulty
+	ethash_h256_t const* boundary
 );
 
 struct ethash_light {


### PR DESCRIPTION
The argument passed into ethash_quick_check_difficulty is not the actual
difficulty but it's 2^256 divided by the difficulty.