### PR TITLE
libethash: use proper bswap on posix, not machine specific

### DIFF
--- a/src/libethash/endian.h
+++ b/src/libethash/endian.h
@@ -41,8 +41,8 @@
 #define ethash_swap_u64(input_) swap64(input_)
 #else // posix
 #include <byteswap.h>
-#define ethash_swap_u32(input_) __bswap_32(input_)
-#define ethash_swap_u64(input_) __bswap_64(input_)
+#define ethash_swap_u32(input_) bswap_32(input_)
+#define ethash_swap_u64(input_) bswap_64(input_)
 #endif
 
 


### PR DESCRIPTION
The `__bswap_32` and `__bswap_64` are not available on all posix systems and/or compilers. Those are part of the machine specific `bits/byteswap.h` headers (e.g. http://www.scs.stanford.edu/histar/src/pkg/uclibc/libc/sysdeps/linux/x86_64/bits/byteswap.h). They are however wrapped by the proper `byteswap.h` header (https://www.gnu.org/software/gnulib/manual/html_node/byteswap_002eh.html) to simply  `bswap_32` and `bswap_64`.

One platform that does **not** implement the underscored versions is the android NDK (e.g. https://android.googlesource.com/platform/development/+/5591a960038d742a936e62fd05ab29adc673fc7f/ndk/platforms/android-3/include/byteswap.h), which uses other functions internally. However, they still honor the true API (underscoreless).

My PR fixes this issue by not using the machine/compiler specific byte swappers, rather than use the proper API ones which will be expanded platform specific.

PS: With this modification, ethash is fully buildable on android.