### PR TITLE
libethash: fix compilation on big endian systems (MIPS64)

### DIFF
--- a/src/libethash/endian.h
+++ b/src/libethash/endian.h
@@ -19,7 +19,7 @@
   # define BYTE_ORDER    LITTLE_ENDIAN
 #elif defined( __QNXNTO__ ) && defined( __BIGENDIAN__ )
   # define BIG_ENDIAN 1234
-  # define BYTE_ORDER    BIG_ENDIAN
+  # define BYTE_ORDER BIG_ENDIAN
 #else
 # include <endian.h>
 #endif
@@ -59,21 +59,20 @@
 
 #define fix_endian32(dst_, src_) dst_ = ethash_swap_u32(src_)
 #define fix_endian32_same(val_) val_ = ethash_swap_u32(val_)
-#define fix_endian64(dst_, src_) dst_ = ethash_swap_u64(src_
+#define fix_endian64(dst_, src_) dst_ = ethash_swap_u64(src_)
 #define fix_endian64_same(val_) val_ = ethash_swap_u64(val_)
-#define fix_endian_arr32(arr_, size_)			\
-	do {										\
-	for (unsigned i_ = 0; i_ < (size_), ++i_) { \
-		arr_[i_] = ethash_swap_u32(arr_[i_]);	\
-	}											\
-	while (0)
-#define fix_endian_arr64(arr_, size_)			\
-	do {										\
-	for (unsigned i_ = 0; i_ < (size_), ++i_) { \
-		arr_[i_] = ethash_swap_u64(arr_[i_]);	\
-	}											\
-	while (0)									\
-
+#define fix_endian_arr32(arr_, size_) \
+  do { \
+    for (unsigned i_ = 0; i_ < (size_); ++i_) { \
+      arr_[i_] = ethash_swap_u32(arr_[i_]); \
+    } \
+  } while (0)
+#define fix_endian_arr64(arr_, size_) \
+  do { \
+    for (unsigned i_ = 0; i_ < (size_); ++i_) { \
+      arr_[i_] = ethash_swap_u64(arr_[i_]); \
+    } \
+  } while (0)
 #else
 # error "endian not supported"
 #endif // BYTE_ORDER

--- a/src/libethash/internal.c
+++ b/src/libethash/internal.c
@@ -257,7 +257,7 @@ static bool ethash_hash(
 void ethash_quick_hash(
 	ethash_h256_t* return_hash,
 	ethash_h256_t const* header_hash,
-	uint64_t const nonce,
+	uint64_t nonce,
 	ethash_h256_t const* mix_hash
 )
 {


### PR DESCRIPTION
The big to little endian conversion macros were completely off (i.e. not compilable due to missing semicolon in the `for`, ~~pointless wrapping `do/while`~~, missing closing curly braces, missing closing paranthesis). Fixed all of these issues.

Further `ethash_quick_hash` used an inplace big->little endian conversion of the `const` nonce, which is obviously not allowed. Fixed by dropping the `const` type constraint from the parameter (it's passed by value anyway so there's no harm in converting it internally).