### PR TITLE
Fix windows compile

### DIFF
--- a/src/python/core.c
+++ b/src/python/core.c
@@ -1,5 +1,4 @@
 #include <Python.h>
-#include <alloca.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <time.h>


### PR DESCRIPTION
This was preventing me from compiling the python bindings on Windows. After some brief investigation, I don't think it's being used anymore (all calls to alloca have been removed or changed to malloc I believe).

