### PR TITLE
include alloca.h only on Linux

### DIFF
--- a/src/python/core.c
+++ b/src/python/core.c
@@ -1,5 +1,9 @@
 #include <Python.h>
-#include <alloca.h>
+#if defined(__linux__)
+    #include <alloca.h>
+#elif defined(_WIN32) || defined(WIN32)
+    #include <malloc.h>
+#endif
 #include <stdint.h>
 #include <stdlib.h>
 #include <time.h>


### PR DESCRIPTION
Hi.

This PR only includes the alloca.h header if compiled for Linux systems.

It appears that the alloca.h header is only available on Linux systems.
ALl BSD's and MacOS expose alloca through stdlib.h
Windows exposes alloca through malloc.h

The Windows part is from @fireflystorm via #104

I've tested this patch under OpenBSD and it works fine.

This should close the issues #80, #87, #104, 

Cheers,
Fabian

References:
stdlib.h
http://man.openbsd.org/OpenBSD-6.3/alloca
http://man.openbsd.org/FreeBSD-11.1/alloca
http://man.openbsd.org/NetBSD-7.1/alloca
http://man.openbsd.org/DragonFly-4.8.0/alloca
https://www.unix.com/man-page/osx/3/alloca/
https://www.unix.com/man-page/opensolaris/3C/alloca/

alloca.h
http://man.openbsd.org/Linux-4.13/alloca