### PR TITLE
fix ethash.go:133: Sprintf format %d reads arg #2, but call has only 1 arg

### DIFF
--- a/ethash.go
+++ b/ethash.go
@@ -130,7 +130,7 @@ func (l *Light) Verify(block Block) bool {
 	// to prevent DOS attacks.
 	blockNum := block.NumberU64()
 	if blockNum >= epochLength*2048 {
-		log.Debug(fmt.Sprintf("block number %d too high, limit is %d", epochLength*2048))
+		log.Debug(fmt.Sprintf("block number %d too high, limit is %d", blockNum, epochLength*2048))
 		return false
 	}
 


### PR DESCRIPTION
BEFORE applying this fix:
```
$ make
[...]
Running 21 test cases...

*** No errors detected
################# Testing Go ##################
# _/home/mk/git/ethereum-ethash
./ethash.go:133: Sprintf format %d reads arg #2, but call has only 1 arg
FAIL	_/home/mk/git/ethereum-ethash [build failed]
Makefile:3: recipe for target 'test' failed
make: *** [test] Error 2
```
AFTER applying this fix:
```
Running 21 test cases...

*** No errors detected
################# Testing Go ##################
PASS
ok  	_/home/mk/git/ethereum-ethash	2.403s
```