### PR TITLE
Fix 'alloca.h' no such file error from windows-os.

### DIFF
--- a/src/python/core.c
+++ b/src/python/core.c
@@ -1,5 +1,5 @@
 #include <Python.h>
-#include <alloca.h>
+#if defined(_WIN32) || defined(WIN32) #include <malloc.h> #else #include <alloca.h> #endif
 #include <stdint.h>
 #include <stdlib.h>
 #include <time.h>


### PR DESCRIPTION
 If it's windows-os 'alloca.h' file will be changed to 'malloc.h' otherwise it's will not changed.