### PR TITLE
Update Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/ethereum/ethash.svg?branch=master)](https://travis-ci.org/ethereum/ethash)
+[![Build Status](https://travis-ci.com/ethereum/ethash.svg?branch=master)](https://travis-ci.com/ethereum/ethash)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/github/debris/ethash?branch=master&svg=true)](https://ci.appveyor.com/project/debris/ethash-nr37r/branch/master)
 
 # Ethash


### PR DESCRIPTION
Please be aware that travis-ci.org will be shutting down in the next weeks, with all accounts and repositories migrating to travis-ci.com.