### PR TITLE
Support for python ``3.10``

### DIFF
--- a/src/python/core.c
+++ b/src/python/core.c
@@ -1,3 +1,5 @@
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 #include <alloca.h>
 #include <stdint.h>


### PR DESCRIPTION
## What was wrong?

- Python 3.10 needs to have ``PY_SSIZE_T_CLEAN`` defined before including ``Python.h`` (https://docs.python.org/3/c-api/arg.html#strings-and-buffers)

## Solution / changes

- Define ``PY_SSIZE_T_CLEAN`` before including ``Python.h``
